### PR TITLE
Standardization

### DIFF
--- a/Pod/Classes/CIRDatabase+GoldDigger.h
+++ b/Pod/Classes/CIRDatabase+GoldDigger.h
@@ -1,0 +1,18 @@
+//
+//  CIRDatabase+GoldDigger.h
+//  GoldDigger
+//
+//  Created by Felipe Lobo on 3/1/16.
+//
+
+#import <SQLAid/CIRDatabase.h>
+
+@interface CIRDatabase (GoldDigger)
+
++ (CIRDatabase *)goldDigger_mainDatabase;
+
++ (void)goldDigger_executeWhenDatabaseIsReady:(void (^)())callback;
+
+- (void)goldDigger_setAsMainDatabase;
+
+@end

--- a/Pod/Classes/CIRDatabase+GoldDigger.m
+++ b/Pod/Classes/CIRDatabase+GoldDigger.m
@@ -1,0 +1,45 @@
+//
+//  CIRDatabase+GoldDigger.m
+//  GoldDigger
+//
+//  Created by Felipe Lobo on 3/1/16.
+//
+
+#import <ObjectiveSugar/NSArray+ObjectiveSugar.h>
+#import <SQLAid/CIRDatabase.h>
+
+static CIRDatabase *GoldDiggerDatabase;
+static NSMutableArray *Callbacks;
+
+@implementation CIRDatabase (GoldDigger)
+
++ (CIRDatabase *)goldDigger_mainDatabase
+{
+	return GoldDiggerDatabase;
+}
+
++ (void)goldDigger_executeWhenDatabaseIsReady:(void (^)())callback
+{
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		Callbacks = [NSMutableArray array];
+	});
+
+	[Callbacks addObject:callback];
+}
+
+- (void)goldDigger_setAsMainDatabase
+{
+	if (GoldDiggerDatabase)
+		@throw [NSException exceptionWithName:@"Main Database Override Exception"
+		                               reason:@"[CIRDatabase+GoldDigger -setAsMainDatabase] throws that you should not override Gold Digger's main database after it was set"
+		                             userInfo:nil];
+
+	[Callbacks each:^(id object) {
+		((void (^)())object)();
+	}];
+
+	GoldDiggerDatabase = self;
+}
+
+@end

--- a/Pod/Classes/GDGBelongsToRelation.h
+++ b/Pod/Classes/GDGBelongsToRelation.h
@@ -1,9 +1,8 @@
 //
 //  GDGBelongsToRelation.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGRelation.h"

--- a/Pod/Classes/GDGBelongsToRelation.m
+++ b/Pod/Classes/GDGBelongsToRelation.m
@@ -1,66 +1,67 @@
 //
 //  GDGBelongsToRelation.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGBelongsToRelation.h"
 
 #import <GoldDigger/GDGConditionBuilder+EntityQuery.h>
+#import <ObjectiveSugar/ObjectiveSugar.h>
 #import "GDGEntityQuery.h"
 #import "GDGEntitySettings.h"
 #import "GDGTableSource.h"
-#import <ObjectiveSugar/ObjectiveSugar.h>
 
 @implementation GDGBelongsToRelation
 
-- (void)fill:(NSArray<GDGEntity*>*)entities withProperties:(NSArray<NSString*>*)properties
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
 {
-	NSArray<NSNumber*>* ids = [entities map:^id(id object) {
+	NSArray<NSNumber *> *ids = [entities map:^id(id object) {
 		return [object valueForKey:self.foreignProperty];
 	}];
-	
-	NSMutableDictionary<NSNumber*, NSMutableArray<GDGEntity*>*>* relationEntitiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:entities.count];
-	for (int i = 0; i < entities.count; i++)
+
+	NSMutableDictionary<NSNumber *, NSMutableArray<GDGEntity *> *> *relationEntitiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:entities.count];
+	for (NSUInteger i = 0; i < entities.count; i++)
 	{
-		GDGEntity* entity = entities[i];
-		NSNumber* foreignId = ids[i];
-		
-		NSMutableArray<GDGEntity*>* mutableEntities = relationEntitiesDictionary[foreignId];
+		GDGEntity *entity = entities[i];
+		NSNumber *foreignId = ids[i];
+
+		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[foreignId];
 		if (mutableEntities == nil)
 		{
 			mutableEntities = [NSMutableArray array];
 			relationEntitiesDictionary[foreignId] = mutableEntities;
 		}
-		
+
 		[mutableEntities addObject:entity];
 	}
-	
-	GDGEntityQuery* query = self.relatedManager.query.select(properties)
-		.where(^(GDGConditionBuilder *builder) { builder.prop(@"id").inList(ids); });
-	
+
+	GDGEntityQuery *query = self.relatedManager.query.select(properties)
+			.where(^(GDGConditionBuilder *builder) {
+				builder.prop(@"id").inList(ids);
+			});
+
 	if (self.condition)
 		query.where(^(GDGConditionBuilder *builder) {
 			builder.and.cat(self.condition);
 		});
-	
-	for (GDGEntity* relatedEntity in query.array)
+
+	for (GDGEntity *relatedEntity in query.array)
 	{
-		NSMutableArray<GDGEntity*>* mutableEntities = relationEntitiesDictionary[@([relatedEntity id])];
-		for (GDGEntity* entity in mutableEntities)
+		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[@([relatedEntity id])];
+		for (GDGEntity *entity in mutableEntities)
 			[entity setValue:relatedEntity forKey:self.name];
 	}
 }
 
-- (NSString*)joinCondition
+- (NSString *)joinCondition
 {
 	NSMutableString *condition = [[NSMutableString alloc] initWithString:self.manager.settings.tableSource.alias];
-	
+
 	[condition appendString:@".id"];
 	[condition appendFormat:@" = %@.%@", self.relatedManager.settings.tableSource.alias, self.foreignProperty];
-	
+
 	return [NSString stringWithString:condition];
 }
 

--- a/Pod/Classes/GDGColumn.h
+++ b/Pod/Classes/GDGColumn.h
@@ -3,33 +3,33 @@
 //  GoldDigger
 //
 //  Created by Pietro Caselani on 1/20/16.
-//  Copyright © 2016 Involves. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, GDGColumnType) {
+typedef NS_ENUM(NSUInteger, GDGColumnType)
+{
+	GDGColumnTypeText,
 	GDGColumnTypeInteger,
 	GDGColumnTypeFloat,
-	GDGColumnTypeText,
 	GDGColumnTypeBlob,
 	GDGColumnTypeDate,
 	GDGColumnTypeDouble,
 	GDGColumnTypeBoolean,
-	GDGColumnTypeNull
+	GDGColumnTypeNone
 };
-
-GDGColumnType GDGColumnFindColumnTypeByName(NSString* typeName);
 
 @interface GDGColumn : NSObject
 
 @property (assign, readonly, nonatomic) GDGColumnType type;
 @property (assign, readonly, nonatomic, getter=isPrimaryKey) BOOL primaryKey;
 @property (assign, readonly, nonatomic, getter=isNotNull) BOOL notNull;
-@property (strong, readonly, nonatomic) NSString* name;
+@property (strong, readonly, nonatomic) NSString *name;
 
-- (instancetype)initWithName:(NSString*)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull;
++ (GDGColumnType)columnTypeFromTypeName:(NSString *)typeName;
 
-- (NSString*)fullName;
+- (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull;
+
+- (NSString *)fullName;
 
 @end

--- a/Pod/Classes/GDGColumn.h
+++ b/Pod/Classes/GDGColumn.h
@@ -16,18 +16,19 @@ typedef NS_ENUM(NSUInteger, GDGColumnType)
 	GDGColumnTypeDate,
 	GDGColumnTypeDouble,
 	GDGColumnTypeBoolean,
-	GDGColumnTypeNone
+	GDGColumnTypeNull
 };
 
 @interface GDGColumn : NSObject
 
+@property (strong, readonly, nonatomic) NSString *name;
 @property (assign, readonly, nonatomic) GDGColumnType type;
 @property (assign, readonly, nonatomic, getter=isPrimaryKey) BOOL primaryKey;
 @property (assign, readonly, nonatomic, getter=isNotNull) BOOL notNull;
-@property (strong, readonly, nonatomic) NSString *name;
 
 + (GDGColumnType)columnTypeFromTypeName:(NSString *)typeName;
 
+- (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type;
 - (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull;
 
 - (NSString *)fullName;

--- a/Pod/Classes/GDGColumn.m
+++ b/Pod/Classes/GDGColumn.m
@@ -3,47 +3,52 @@
 //  GoldDigger
 //
 //  Created by Pietro Caselani on 1/20/16.
-//  Copyright © 2016 Involves. All rights reserved.
 //
 
 #import "GDGColumn.h"
-
 #import "GDGSource.h"
-
-GDGColumnType GDGColumnFindColumnTypeByName(NSString* typeName)
-{
-	GDGColumnType type;
-	
-	if ([typeName caseInsensitiveCompare:@"integer"] == NSOrderedSame) type = GDGColumnTypeInteger;
-	else if ([typeName caseInsensitiveCompare:@"float"] == NSOrderedSame) type = GDGColumnTypeFloat;
-	else if ([typeName caseInsensitiveCompare:@"text"] == NSOrderedSame) type = GDGColumnTypeText;
-	else if ([typeName caseInsensitiveCompare:@"blob"] == NSOrderedSame) type = GDGColumnTypeBlob;
-	else if ([typeName caseInsensitiveCompare:@"date"] == NSOrderedSame) type = GDGColumnTypeDate;
-	else if ([typeName caseInsensitiveCompare:@"double"] == NSOrderedSame) type = GDGColumnTypeDouble;
-	else if ([typeName caseInsensitiveCompare:@"boolean"] == NSOrderedSame) type = GDGColumnTypeBoolean;
-	else type = GDGColumnTypeNull;
-	
-	return type;
-}
 
 @implementation GDGColumn
 
-- (instancetype)initWithName:(NSString*)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull
++ (GDGColumnType)columnTypeFromTypeName:(NSString *)typeName
 {
-	if (self = [super init])
+	GDGColumnType type;
+
+	if ([typeName caseInsensitiveCompare:@"integer"] == NSOrderedSame)
+		type = GDGColumnTypeInteger;
+	else if ([typeName caseInsensitiveCompare:@"float"] == NSOrderedSame)
+		type = GDGColumnTypeFloat;
+	else if ([typeName caseInsensitiveCompare:@"text"] == NSOrderedSame)
+		type = GDGColumnTypeText;
+	else if ([typeName caseInsensitiveCompare:@"blob"] == NSOrderedSame)
+		type = GDGColumnTypeBlob;
+	else if ([typeName caseInsensitiveCompare:@"date"] == NSOrderedSame)
+		type = GDGColumnTypeDate;
+	else if ([typeName caseInsensitiveCompare:@"double"] == NSOrderedSame)
+		type = GDGColumnTypeDouble;
+	else if ([typeName caseInsensitiveCompare:@"boolean"] == NSOrderedSame)
+		type = GDGColumnTypeBoolean;
+	else
+		type = GDGColumnTypeNone;
+
+	return type;
+}
+
+- (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull
+{
+	self = [super init];
+	if (self)
 	{
 		_name = name;
 		_type = type;
 		_primaryKey = primaryKey;
 		_notNull = notNull;
-		
-		return self;
 	}
-	
-	return nil;
+
+	return self;
 }
 
-- (NSString*)fullName
+- (NSString *)fullName
 {
 	return [self.source.alias stringByAppendingFormat:@".%@", _name];
 }

--- a/Pod/Classes/GDGColumn.m
+++ b/Pod/Classes/GDGColumn.m
@@ -29,9 +29,14 @@
 	else if ([typeName caseInsensitiveCompare:@"boolean"] == NSOrderedSame)
 		type = GDGColumnTypeBoolean;
 	else
-		type = GDGColumnTypeNone;
+		type = GDGColumnTypeNull;
 
 	return type;
+}
+
+- (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type
+{
+	return [self initWithName:name type:type primaryKey:NO notNull:NO];
 }
 
 - (instancetype)initWithName:(NSString *)name type:(GDGColumnType)type primaryKey:(BOOL)primaryKey notNull:(BOOL)notNull

--- a/Pod/Classes/GDGConditionBuilder+EntityQuery.h
+++ b/Pod/Classes/GDGConditionBuilder+EntityQuery.h
@@ -1,9 +1,8 @@
 //
 //  GDGConditionBuilder+EntityQuery.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGConditionBuilder.h"
@@ -13,8 +12,8 @@
 @interface GDGConditionBuilder (EntityQuery)
 
 @property (readonly, nonatomic) GDGEntityQuery *query;
-@property (copy, readonly, nonatomic) GDGConditionBuilder* (^prop)(NSString*);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^prop)(NSString *);
 
-- (instancetype)initWithEntityQuery:(GDGEntityQuery *)entityQuery;
++ (instancetype)builderWithEntityQuery:(GDGEntityQuery *)entityQuery;
 
 @end

--- a/Pod/Classes/GDGConditionBuilder+EntityQuery.m
+++ b/Pod/Classes/GDGConditionBuilder+EntityQuery.m
@@ -1,9 +1,8 @@
 //
 //  GDGConditionBuilder+EntityQuery.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGConditionBuilder+EntityQuery.h"
@@ -14,19 +13,17 @@
 
 @implementation GDGConditionBuilder (EntityQuery)
 
-- (instancetype)initWithEntityQuery:(GDGEntityQuery *)entityQuery
++ (instancetype)builderWithEntityQuery:(GDGEntityQuery *)entityQuery;
 {
-	if (self = [self init])
-	{
-		self.query = entityQuery;
-	}
+	GDGConditionBuilder *builder = [[self alloc] init];
+	builder.query = entityQuery;
 
-	return self;
+	return builder;
 }
 
 - (GDGEntityQuery *)query
 {
-	return objc_getAssociatedObject(self, @selector(query));
+	return objc_getAssociatedObject(self, _cmd);
 }
 
 - (void)setQuery:(GDGEntityQuery *)query
@@ -34,24 +31,24 @@
 	objc_setAssociatedObject(self, @selector(query), query, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-
-- (GDGConditionBuilder *(^)(NSString*))prop
+- (GDGConditionBuilder *(^)(NSString *))prop
 {
-	GDGConditionBuilder *(^prop)(NSString *) = objc_getAssociatedObject(self, @selector(prop));
-	if (prop == nil) {
+	GDGConditionBuilder *(^prop)(NSString *) = objc_getAssociatedObject(self, _cmd);
+	if (prop == nil)
+	{
 		__weak typeof(self) weakSelf = self;
-		
-		prop = ^GDGConditionBuilder* (NSString *property) {
+
+		prop = ^GDGConditionBuilder *(NSString *property) {
 			GDGEntityQuery *query = weakSelf.query;
-			
+
 			NSInteger dotIndex = [property rangeOfString:@"."].location;
-			
+
 			return weakSelf.col([query.manager columnForProperty:dotIndex == NSNotFound ? property : [property substringFromIndex:(NSUInteger) (dotIndex + 1)]]);
 		};
-		
-		objc_setAssociatedObject(self, @selector(prop), prop, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+		objc_setAssociatedObject(self, _cmd, prop, OBJC_ASSOCIATION_COPY_NONATOMIC);
 	}
-	
+
 	return prop;
 }
 

--- a/Pod/Classes/GDGConditionBuilder.h
+++ b/Pod/Classes/GDGConditionBuilder.h
@@ -1,9 +1,8 @@
 //
 //  GDGConditionBuilder.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/8/16.
-//
 //
 
 #import <Foundation/Foundation.h>
@@ -13,18 +12,18 @@
 
 @interface GDGConditionBuilder : NSObject
 
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^build)(void (^)(GDGConditionBuilder *));
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^col)(GDGColumn *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^cat)(GDGConditionBuilder *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^equals)(id);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^notEquals)(id);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^isNull)();
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^isNotNull)();
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^equalsDate)(NSString *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^equalsCol)(GDGColumn *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^inText)(NSString *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^inList)(NSArray<NSNumber *> *);
-@property(copy, readonly, nonatomic) GDGConditionBuilder *(^inQuery)(GDGQuery *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^build)(void (^)(GDGConditionBuilder *));
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^col)(GDGColumn *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^cat)(GDGConditionBuilder *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^equals)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^notEquals)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^isNull)();
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^isNotNull)();
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^equalsDate)(NSString *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^equalsCol)(GDGColumn *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^inText)(NSString *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^inList)(NSArray<NSNumber *> *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^inQuery)(GDGQuery *);
 
 + (instancetype)builder;
 
@@ -39,5 +38,7 @@
 - (GDGConditionBuilder *)closeParentheses;
 
 - (NSString *)visit;
+
+- (BOOL)isEmpty;
 
 @end

--- a/Pod/Classes/GDGConditionBuilder.m
+++ b/Pod/Classes/GDGConditionBuilder.m
@@ -1,9 +1,8 @@
 //
 //  GDGConditionBuilder.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/8/16.
-//
 //
 
 #import "GDGConditionBuilder.h"
@@ -14,8 +13,8 @@
 
 @interface GDGConditionBuilder ()
 
-@property (strong, nonatomic) NSMutableArray<NSString*> *strings;
-@property (strong, nonatomic) NSMutableDictionary<NSString*, id> *args;
+@property (strong, nonatomic) NSMutableArray<NSString *> *strings;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *args;
 
 @end
 
@@ -32,54 +31,54 @@
 	{
 		_strings = [[NSMutableArray alloc] init];
 		_args = [[NSMutableDictionary alloc] init];
-		
+
 		__weak __typeof(self) weakSelf = self;
-		
+
 		_col = ^GDGConditionBuilder *(GDGColumn *column) {
 			[weakSelf.strings addObject:column.fullName];
 			return weakSelf;
 		};
-		
+
 		_equals = ^GDGConditionBuilder *(id value) {
 			return [weakSelf appendValue:value forOperator:@"="];
 		};
-		
+
 		_notEquals = ^GDGConditionBuilder *(id value) {
 			return [weakSelf appendValue:value forOperator:@"<>"];
 		};
-		
-		_build = ^GDGConditionBuilder *(void (^ builderHandler)(GDGConditionBuilder *)) {
+
+		_build = ^GDGConditionBuilder *(void (^builderHandler)(GDGConditionBuilder *)) {
 			return [weakSelf build:builderHandler];
 		};
-		
-		_isNull = ^GDGConditionBuilder *{
+
+		_isNull = ^GDGConditionBuilder * {
 			return [weakSelf appendText:@"IS NULL"];
 		};
-		
-		_isNotNull = ^GDGConditionBuilder *{
+
+		_isNotNull = ^GDGConditionBuilder * {
 			return [weakSelf appendText:@"IS NOT NULL"];
 		};
-		
+
 		_equalsDate = ^GDGConditionBuilder *(NSString *dateString) {
 			NSString *columnName = [weakSelf.strings lastObject];
-			
+
 			return [weakSelf appendValue:dateString forOperator:[NSString stringWithFormat:@"DATE(%@) = ", columnName]];
 		};
-		
+
 		_equalsCol = ^GDGConditionBuilder *(GDGColumn *column) {
 			[weakSelf.strings addObject:[NSString stringWithFormat:@" = %@", column.fullName]];
 			return weakSelf;
 		};
-		
+
 		_inText = ^GDGConditionBuilder *(NSString *text) {
 			return [weakSelf appendText:[NSString stringWithFormat:@" IN (%@)", text]];
 		};
-		
-		_inList = ^GDGConditionBuilder *(NSArray<NSNumber*> *array) {
+
+		_inList = ^GDGConditionBuilder *(NSArray<NSNumber *> *array) {
 			NSString *arrayString = [[array map:^id(id object) {
 				return [NSString stringWithFormat:@"%d", [object intValue]];
 			}] join:@", "];
-			
+
 			return weakSelf.inText(arrayString);
 		};
 
@@ -87,12 +86,12 @@
 			[weakSelf.args addEntriesFromDictionary:builder.args];
 			return [[weakSelf and] appendText:builder.visit];
 		};
-		
+
 		_inQuery = ^GDGConditionBuilder *(GDGQuery *query) {
-			NSDictionary<NSString*, id> *arguments = query.arguments;
+			NSDictionary<NSString *, id> *arguments = query.arguments;
 			NSString *sql = query.visit;
 
-			NSMutableDictionary<NSString*, id> *newArguments = [[NSMutableDictionary alloc] initWithCapacity:arguments.count];
+			NSMutableDictionary<NSString *, id> *newArguments = [[NSMutableDictionary alloc] initWithCapacity:arguments.count];
 
 			for (NSString *key in arguments.allKeys)
 			{
@@ -114,11 +113,11 @@
 			return weakSelf.inText(sql);
 		};
 	}
-	
+
 	return self;
 }
 
-- (GDGConditionBuilder*)build:(void (^)(GDGConditionBuilder*))builder
+- (GDGConditionBuilder *)build:(void (^)(GDGConditionBuilder *))builder
 {
 	[self appendText:@"("];
 	builder(self);
@@ -126,27 +125,27 @@
 	return self;
 }
 
-- (GDGConditionBuilder*)and
+- (GDGConditionBuilder *)and
 {
 	return [self appendText:@"AND"];
 }
 
-- (GDGConditionBuilder*)or
+- (GDGConditionBuilder *)or
 {
 	return [self appendText:@"OR"];
 }
 
-- (GDGConditionBuilder*)openParentheses
+- (GDGConditionBuilder *)openParentheses
 {
 	return [self appendText:@"("];
 }
 
-- (GDGConditionBuilder*)closeParentheses
+- (GDGConditionBuilder *)closeParentheses
 {
 	return [self appendText:@")"];
 }
 
-- (GDGConditionBuilder*)appendValue:(id)value forOperator:(NSString *)operator
+- (GDGConditionBuilder *)appendValue:(id)value forOperator:(NSString *)operator
 {
 	NSString *propertyName = [_strings lastObject];
 
@@ -154,22 +153,22 @@
 
 	if (dotIndex != NSNotFound)
 		propertyName = [propertyName substringFromIndex:dotIndex + 1];
-	
+
 	unsigned int random = arc4random() % 100;
-	
+
 	NSString *argumentName = [NSString stringWithFormat:@"%@%u", propertyName, random];
-	
+
 	[_strings addObject:[NSString stringWithFormat:@" %@ :%@", operator, argumentName]];
 
 	_args[argumentName] = value;
-	
+
 	return self;
 }
 
-- (GDGConditionBuilder*)appendText:(NSString *)text
+- (GDGConditionBuilder *)appendText:(NSString *)text
 {
 	[_strings addObject:[NSString stringWithFormat:@" %@ ", text]];
-	
+
 	return self;
 }
 
@@ -178,9 +177,14 @@
 	return [NSDictionary dictionaryWithDictionary:_args];
 }
 
-- (NSString*)visit
+- (NSString *)visit
 {
 	return [_strings join];
+}
+
+- (BOOL)isEmpty
+{
+	return _strings.count == 0;
 }
 
 @end

--- a/Pod/Classes/GDGConditionBuilder_Protected.h
+++ b/Pod/Classes/GDGConditionBuilder_Protected.h
@@ -1,15 +1,14 @@
 //
 //  GDGConditionBuilder_Protected.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/19/16.
-//
 //
 
 #import "GDGConditionBuilder.h"
 
 @interface GDGConditionBuilder ()
 
-- (NSDictionary<NSString*, id> *)arguments;
+- (NSDictionary<NSString *, id> *)arguments;
 
 @end

--- a/Pod/Classes/GDGEntity.h
+++ b/Pod/Classes/GDGEntity.h
@@ -3,7 +3,6 @@
 //  GoldDigger
 //
 //  Created by Pietro Caselani on 1/20/16.
-//  Copyright © 2016 Involves. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,21 +12,21 @@
 
 @protocol GDGEntityFillDelegate <NSObject>
 
-- (void)entity:(GDGEntity*)entity hasFilledPropertyNamed:(NSString*)propertyName;
-- (void)entity:(GDGEntity*)entity requestToFillPropertyNamed:(NSString*)propertyName;
+- (void)entity:(GDGEntity *)entity hasFilledPropertyNamed:(NSString *)propertyName;
+
+- (void)entity:(GDGEntity *)entity requestToFillPropertyNamed:(NSString *)propertyName;
 
 @end
 
 @interface GDGEntity : NSObject
 
 @property (assign, nonatomic) NSUInteger id;
-@property (readonly, nonatomic) GDGEntityManager<GDGEntityFillDelegate>* db;
+@property (readonly, nonatomic) GDGEntityManager <GDGEntityFillDelegate> *db;
 
-- (BOOL)save;
-- (BOOL)drop;
++ (instancetype)entity;
+
++ (void)autoFillProperties:(NSArray<NSString *> *)propertiesNames;
 
 - (BOOL)isEqualToEntity:(GDGEntity *)entity;
-
-+ (void)autoFillProperties:(NSArray<NSString*>*)propertiesNames;
 
 @end

--- a/Pod/Classes/GDGEntity.m
+++ b/Pod/Classes/GDGEntity.m
@@ -3,32 +3,28 @@
 //  GoldDigger
 //
 //  Created by Pietro Caselani on 1/20/16.
-//  Copyright © 2016 Involves. All rights reserved.
 //
 
 #import "GDGEntity.h"
 
-#import "GDGEntityManager.h"
 #import <objc/runtime.h>
+#import "GDGEntityManager.h"
 
 @implementation GDGEntity
 
 @synthesize db = _db;
 
-- (GDGEntityManager*)db
++ (instancetype)entity
+{
+	return [[self alloc] init];
+}
+
+- (GDGEntityManager *)db
 {
 	return _db ? _db : (_db = [[GDGEntityManager alloc] initWithEntity:self]);
 }
 
-- (BOOL)save
-{
-	return [self.db save];
-}
-
-- (BOOL)drop
-{
-	return [self.db drop];
-}
+#pragma mark - Equality
 
 - (BOOL)isEqualToEntity:(GDGEntity *)entity
 {
@@ -39,7 +35,7 @@
 {
 	if (self == object)
 		return YES;
-	
+
 	return [self isEqualToEntity:object];
 }
 
@@ -48,13 +44,15 @@
 	return self.id * 11;
 }
 
-+ (void)autoFillProperties:(NSArray<NSString*>*)propertiesNames
+#pragma mark - Property hacking
+
++ (void)autoFillProperties:(NSArray<NSString *> *)propertiesNames
 {
-	NSString* className = NSStringFromClass([self class]);
-	
+	NSString *className = NSStringFromClass([self class]);
+
 	id clazz = objc_getClass(className.UTF8String);
-	
-	for (NSString* propertyName in propertiesNames)
+
+	for (NSString *propertyName in propertiesNames)
 	{
 		objc_property_t property = class_getProperty(clazz, propertyName.UTF8String);
 		[self overrideSetter:property forClass:clazz];
@@ -64,123 +62,136 @@
 
 + (void)overrideSetter:(objc_property_t)property forClass:(Class)clazz
 {
-	NSString* propertyName = [NSString stringWithUTF8String:property_getName(property)], *setterName;
-	
-	char* csetterName = property_copyAttributeValue(property, "S");
-	if (csetterName == NULL)
-		setterName = [NSString stringWithFormat:@"set%@:", [propertyName stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[[propertyName substringToIndex:1] uppercaseString]]];
-	else
-		setterName = [NSString stringWithUTF8String:csetterName];
-	
-	SEL setterSelector = NSSelectorFromString(setterName);
+	NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
+
+	char *cstrSignature = property_copyAttributeValue(property, "S");
+
+	NSString *signature = cstrSignature == NULL ?
+			[NSString stringWithFormat:@"set%@:", [propertyName stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:[[propertyName substringToIndex:1] uppercaseString]]] :
+			@(cstrSignature);
+
+	SEL setterSelector = NSSelectorFromString(signature);
 	Method setter = class_getInstanceMethod(clazz, setterSelector);
 	IMP setterImplementation = method_getImplementation(setter);
-	
+
 	char type = property_getAttributes(property)[1];
-	
+
 #define SETTER_IMP_BLOCK(T) ^(GDGEntity* _self, T argument) { \
-		[_self.db entity:_self hasFilledPropertyNamed:propertyName]; \
-		((void(*)(GDGEntity*, SEL, T)) setterImplementation)(_self, setterSelector, argument); \
-	}
-	
+        [_self.db entity:_self hasFilledPropertyNamed:propertyName]; \
+        ((void(*)(GDGEntity*, SEL, T)) setterImplementation)(_self, setterSelector, argument); \
+    }
+
 	id block;
-	switch (type) {
-		case '@': {
+	switch (type)
+	{
+		case '@':
+		{
 			block = SETTER_IMP_BLOCK(id);
 			break;
 		}
 		case 'i':
 		case 'l':
-		case 's': {
+		case 's':
+		{
 			block = SETTER_IMP_BLOCK(NSInteger);
 			break;
 		}
-		case 'c': {
+		case 'c':
+		{
 			block = SETTER_IMP_BLOCK(char);
 			break;
 		}
-		case 'I': {
+		case 'I':
+		{
 			block = SETTER_IMP_BLOCK(NSUInteger);
 			break;
 		}
-		case 'd': {
+		case 'd':
+		{
 			block = SETTER_IMP_BLOCK(double);
 			break;
 		}
-		case 'f': {
+		case 'f':
+		{
 			block = SETTER_IMP_BLOCK(float);
 			break;
 		}
 		default:
 			@throw [NSException exceptionWithName:@"Setter Type Not Handled Exception" reason:[NSString stringWithFormat:@"[GDGEntity -overrideSetter:forClass:] throws that the type %c cannot be handled", type] userInfo:nil];
-			break;
 	}
-	
+
 #undef SETTER_IMP_BLOCK
-	
+
 	IMP fillSetterImplementation = imp_implementationWithBlock(block);
 	method_setImplementation(setter, fillSetterImplementation);
-	
-	free(csetterName);
+
+	free(cstrSignature);
 }
 
 + (void)overrideGetter:(objc_property_t)property forClass:(Class)clazz
 {
-	NSString* propertyName = [NSString stringWithUTF8String:property_getName(property)];
-	
-	char* cgetterName = property_copyAttributeValue(property, "G");
-	NSString* getterName = cgetterName == NULL ? propertyName : [NSString stringWithUTF8String:cgetterName];
-	
-	SEL getterSelector = NSSelectorFromString(getterName);
+	NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
+
+	char *cstrSignature = property_copyAttributeValue(property, "G");
+
+	NSString *signature = cstrSignature == NULL ? propertyName : @(cstrSignature);
+
+	SEL getterSelector = NSSelectorFromString(signature);
 	Method getter = class_getInstanceMethod(clazz, getterSelector);
 	IMP getterImplementation = method_getImplementation(getter);
-	
+
 	char type = property_getAttributes(property)[1];
-	
+
 #define GETTER_IMP_BLOCK(T) ^(GDGEntity* _self) { \
-		[_self.db entity:_self requestToFillPropertyNamed:propertyName]; \
-		return ((T(*)(GDGEntity*, SEL)) getterImplementation)(_self, getterSelector); \
-	}
+        [_self.db entity:_self requestToFillPropertyNamed:propertyName]; \
+        return ((T(*)(GDGEntity*, SEL)) getterImplementation)(_self, getterSelector); \
+    }
 
 	id block;
-	switch (type) {
-		case '@': {
+	switch (type)
+	{
+		case '@':
+		{
 			block = GETTER_IMP_BLOCK(id);
 			break;
 		}
 		case 'i':
 		case 'l':
-		case 's': {
+		case 's':
+		{
 			block = GETTER_IMP_BLOCK(NSInteger);
 			break;
 		}
-		case 'c': {
+		case 'c':
+		{
 			block = GETTER_IMP_BLOCK(char);
 			break;
 		}
-		case 'I': {
+		case 'I':
+		{
 			block = GETTER_IMP_BLOCK(NSUInteger);
 			break;
 		}
-		case 'd': {
+		case 'd':
+		{
 			block = GETTER_IMP_BLOCK(double);
 			break;
 		}
-		case 'f': {
+		case 'f':
+		{
 			block = GETTER_IMP_BLOCK(float);
 			break;
 		}
 		default:
 			@throw [NSException exceptionWithName:@"Setter Type Not Handled Exception" reason:[NSString stringWithFormat:@"[GDGEntity -overrideSetter:forClass:] throws that the type %c cannot be handled", type] userInfo:nil];
-			break;
 	}
-	
+
 #undef GETTER_IMP_BLOCK
-	
+
 	IMP autoFillGetterImplementation = imp_implementationWithBlock(block);
 	method_setImplementation(getter, autoFillGetterImplementation);
-	
-	free(cgetterName);
+
+	free(cstrSignature);
 }
 
 @end

--- a/Pod/Classes/GDGEntityManager.h
+++ b/Pod/Classes/GDGEntityManager.h
@@ -3,7 +3,6 @@
 //  GoldDigger
 //
 //  Created by Pietro Caselani on 1/20/16.
-//  Copyright © 2016 Involves. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,23 +12,14 @@
 @class GDGEntitySettings;
 @class GDGHasOneRelation, GDGHasManyRelation, GDGBelongsToRelation;
 @class GDGEntityQuery;
-@class GDGValueAdapter;
 @class GDGTableSource;
 @class CIRDatabase;
 @class GDGColumn;
 
 @interface GDGEntityManager : NSObject <GDGEntityFillDelegate>
 
-@property(weak, readonly, nonatomic) GDGEntitySettings *settings;
-@property(weak, readonly, nonatomic) GDGEntity *entity;
-
-+ (GDGTableSource *)tableSourceWithName:(NSString *)tableName;
-
-+ (void)executeOnDatabaseReady:(void (^)())callback;
-
-+ (void)setDatabase:(CIRDatabase *)database;
-
-+ (CIRDatabase *)database;
+@property (weak, readonly, nonatomic) GDGEntitySettings *settings;
+@property (weak, readonly, nonatomic) GDGEntity *entity;
 
 - (instancetype)initWithEntity:(GDGEntity *)entity;
 
@@ -45,6 +35,12 @@
 
 - (BOOL)drop;
 
+- (void)hasMany:(NSString *)relationName config:(void (^)(GDGHasManyRelation *))tap;
+
+- (void)hasOne:(NSString *)relationName config:(void (^)(GDGHasOneRelation *))tap;
+
+- (void)belongsTo:(NSString *)relationName config:(void (^)(GDGBelongsToRelation *))tap;
+
 - (void)fillProperties:(NSArray<NSString *> *)properties;
 
 - (void)fillEntities:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties;
@@ -55,14 +51,6 @@
 
 - (GDGColumn *)columnForProperty:(NSString *)propertyName;
 
-- (void)addValueAdapterForPropertyNamed:(NSString *)propertyName fromDatabaseHandler:(id (^)(id))fromDatabaseHandler toDatabaseHandler:(id (^)(id))toDatabaseHandler;
-
-- (void)addValueAdapterForPropertyNamed:(NSString *)propertyName valueAdapter:(NSValueTransformer *)valueAdapter;
-
-- (void)hasMany:(NSString *)relationName config:(void (^)(GDGHasManyRelation *))tap;
-
-- (void)hasOne:(NSString *)relationName config:(void (^)(GDGHasOneRelation *))tap;
-
-- (void)belongsTo:(NSString *)relationName config:(void (^)(GDGBelongsToRelation *))tap;
+- (void)addValueTransformer:(__kindof NSValueTransformer *)transformer forProperties:(NSArray<NSString *> *)properties;
 
 @end

--- a/Pod/Classes/GDGEntityQuery.h
+++ b/Pod/Classes/GDGEntityQuery.h
@@ -1,9 +1,8 @@
 //
 //  GDGEntityQuery.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGQuery.h"
@@ -11,12 +10,20 @@
 @class GDGEntityManager;
 @class GDGEntity;
 
+@interface GDGQuery (Entity)
+
+- (NSArray<__kindof GDGEntity *> *)array;
+
+- (__kindof GDGEntity *)object;
+
+@end
+
 @interface GDGEntityQuery : GDGQuery
 
-@property (copy, readonly, nonatomic) GDGEntityQuery* (^joinRelation)(NSString*, NSArray<NSString*>*);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^joinRelation)(NSString *, NSArray<NSString *> *);
 
 @property (readonly, nonatomic) GDGEntityManager *manager;
 
-- (instancetype)initWithManager:(GDGEntityManager*)manager;
+- (instancetype)initWithManager:(GDGEntityManager *)manager;
 
 @end

--- a/Pod/Classes/GDGEntitySettings.h
+++ b/Pod/Classes/GDGEntitySettings.h
@@ -1,9 +1,8 @@
 //
 //  GDGEntitySettings.h
-//  RuntimeiOS
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/21/16.
-//  Copyright © 2016 Pietro Caselani. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -14,12 +13,10 @@
 @interface GDGEntitySettings : NSObject
 
 @property (assign, readonly, nonatomic) Class entityClass;
-@property (strong, nonatomic) GDGTableSource* tableSource;
-@property (strong, nonatomic) NSDictionary<NSString*, NSString*>* columnsDictionary;
-@property (strong, nonatomic) NSDictionary<NSString*, NSString*>* propertiesDictionary;
+@property (strong, nonatomic) GDGTableSource *tableSource;
+@property (strong, nonatomic) NSDictionary<NSString *, NSString *> *columnsDictionary;
+@property (strong, nonatomic) NSDictionary<NSString *, NSString *> *propertiesDictionary;
 
 - (instancetype)initWithEntityClass:(Class)entityClass;
-
-- (void)addValueAdpter:(NSValueTransformer*)valueAdapter forPropertyNamed:(NSString*)propertyName;
 
 @end

--- a/Pod/Classes/GDGEntitySettings.m
+++ b/Pod/Classes/GDGEntitySettings.m
@@ -1,9 +1,8 @@
 //
 //  GDGEntitySettings.m
-//  RuntimeiOS
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/21/16.
-//  Copyright © 2016 Pietro Caselani. All rights reserved.
 //
 
 #import "GDGEntitySettings.h"
@@ -19,29 +18,24 @@
 	{
 		_entityClass = entityClass;
 		_relationNameDictionary = [NSMutableDictionary dictionary];
-		_valueAdapterDictionary = [NSMutableDictionary dictionary];
+		_valueTransformerDictionary = [NSMutableDictionary dictionary];
 	}
-	
+
 	return self;
 }
 
-- (void)addValueAdpter:(NSValueTransformer*)valueAdapter forPropertyNamed:(NSString*)propertyName
-{
-	_valueAdapterDictionary[propertyName] = valueAdapter;
-}
-
-- (void)setColumnsDictionary:(NSDictionary<NSString*,NSString*>*)columnsDictionary
+- (void)setColumnsDictionary:(NSDictionary<NSString *, NSString *> *)columnsDictionary
 {
 	_columnsDictionary = columnsDictionary;
-	
+
 	NSMutableDictionary *propertiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:columnsDictionary.count];
-	
+
 	for (NSString *key in columnsDictionary)
 	{
 		NSString *value = columnsDictionary[key];
 		propertiesDictionary[value] = key;
 	}
-	
+
 	_propertiesDictionary = propertiesDictionary;
 }
 

--- a/Pod/Classes/GDGEntitySettings_Relations.h
+++ b/Pod/Classes/GDGEntitySettings_Relations.h
@@ -1,16 +1,15 @@
 //
 //  GDGEntitySettings_Relations.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGEntitySettings.h"
 
 @interface GDGEntitySettings ()
 
-@property (strong, nonatomic) NSMutableDictionary<NSString*, GDGRelation*>* relationNameDictionary;
-@property (strong, nonatomic) NSMutableDictionary<NSString*, NSValueTransformer*>* valueAdapterDictionary;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, GDGRelation *> *relationNameDictionary;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, NSValueTransformer *> *valueTransformerDictionary;
 
 @end

--- a/Pod/Classes/GDGHasManyRelation.h
+++ b/Pod/Classes/GDGHasManyRelation.h
@@ -1,9 +1,8 @@
 //
 //  GDGHasManyRelation.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGRelation.h"

--- a/Pod/Classes/GDGHasManyRelation.m
+++ b/Pod/Classes/GDGHasManyRelation.m
@@ -1,9 +1,8 @@
 //
 //  GDGHasManyRelation.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGHasManyRelation.h"
@@ -14,66 +13,66 @@
 
 @implementation GDGHasManyRelation
 
-- (void)fill:(NSArray<GDGEntity*>*)entities withProperties:(NSArray<NSString*>*)properties
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
 {
-	NSArray<NSNumber*>* ids = [entities map:^id(id object) {
+	NSArray<NSNumber *> *ids = [entities map:^id(id object) {
 		return @([object id]);
 	}];
-	
-	NSMutableDictionary<NSNumber*, NSMutableArray<GDGEntity*>*>* relationEntitiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:entities.count];
-	
-	for (int i = 0; i < entities.count; i++)
+
+	NSMutableDictionary<NSNumber *, NSMutableArray<GDGEntity *> *> *relationEntitiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:entities.count];
+
+	for (NSUInteger i = 0; i < entities.count; i++)
 	{
-		GDGEntity* entity = entities[i];
-		NSNumber* foreignId = ids[i];
-		
-		NSMutableArray<GDGEntity*>* mutableEntities = relationEntitiesDictionary[foreignId];
+		GDGEntity *entity = entities[i];
+		NSNumber *foreignId = ids[i];
+
+		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[foreignId];
 		if (mutableEntities == nil)
 		{
 			mutableEntities = [NSMutableArray array];
 			relationEntitiesDictionary[foreignId] = mutableEntities;
 		}
-		
+
 		[mutableEntities addObject:entity];
 	}
-	
-	NSMutableArray* mutableProperties = [NSMutableArray arrayWithArray:properties];
-	
+
+	NSMutableArray *mutableProperties = [NSMutableArray arrayWithArray:properties];
+
 	[mutableProperties addObject:self.foreignProperty];
-	
-	GDGEntityQuery* query = self.relatedManager.query.select([NSArray arrayWithArray:mutableProperties])
-		.where(^(GDGConditionBuilder *builder) {
-			builder.prop(self.foreignProperty).inList(ids);
-		});
-	
+
+	GDGEntityQuery *query = self.relatedManager.query.select([NSArray arrayWithArray:mutableProperties])
+			.where(^(GDGConditionBuilder *builder) {
+				builder.prop(self.foreignProperty).inList(ids);
+			});
+
 	if (self.condition)
 		query.where(^(GDGConditionBuilder *builder) {
 			builder.and.cat(self.condition);
 		});
-	
-	NSMutableDictionary<NSNumber*, NSMutableArray*>* idRelationDictionary = [[NSMutableDictionary alloc] init];
-	
-	for (GDGEntity* relatedEntity in query.array)
+
+	NSMutableDictionary<NSNumber *, NSMutableArray *> *idRelationDictionary = [[NSMutableDictionary alloc] init];
+
+	for (GDGEntity *relatedEntity in query.array)
 	{
-		NSMutableArray* mutableEntities = relationEntitiesDictionary[[relatedEntity valueForKey:self.foreignProperty]];
-		
-		for (GDGEntity* entity in mutableEntities)
+		NSMutableArray *mutableEntities = relationEntitiesDictionary[[relatedEntity valueForKey:self.foreignProperty]];
+
+		for (GDGEntity *entity in mutableEntities)
 		{
-			NSMutableArray* relations = idRelationDictionary[@([entity id])];
+			NSMutableArray *relations = idRelationDictionary[@([entity id])];
 			if (relations == nil)
 			{
 				relations = [NSMutableArray array];
 				idRelationDictionary[@([entity id])] = relations;
 			}
-			
+
 			[relations addObject:relatedEntity];
 		}
 	}
-	
-	for (GDGEntity* entity in entities)
+
+	for (GDGEntity *entity in entities)
 	{
-		NSMutableArray* relatedEntities = idRelationDictionary[@([entity id])];
-		
+		NSMutableArray *relatedEntities = idRelationDictionary[@([entity id])];
+
 		[entity setValue:[NSArray arrayWithArray:relatedEntities] forKey:self.name];
 	}
 }

--- a/Pod/Classes/GDGHasOneRelation.h
+++ b/Pod/Classes/GDGHasOneRelation.h
@@ -1,9 +1,8 @@
 //
 //  GDGHasOneRelation.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGRelation.h"

--- a/Pod/Classes/GDGHasOneRelation.m
+++ b/Pod/Classes/GDGHasOneRelation.m
@@ -1,9 +1,8 @@
 //
 //  GDGHasOneRelation.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGHasOneRelation.h"
@@ -14,30 +13,30 @@
 
 @implementation GDGHasOneRelation
 
-- (void)fill:(NSArray<GDGEntity*>*)entities withProperties:(NSArray<NSString*>*)properties
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
 {
-	NSArray<NSNumber*>* ids = [entities map:^id(id object) {
+	NSArray<NSNumber *> *ids = [entities map:^id(id object) {
 		return @([object id]);
 	}];
-	
-	NSDictionary<NSNumber*, GDGEntity*>* idEntitiesDictionary = [NSDictionary dictionaryWithObjects:entities forKeys:ids];
-	
-	NSMutableArray* mutableProperties = [NSMutableArray arrayWithArray:properties];
+
+	NSDictionary<NSNumber *, GDGEntity *> *idEntitiesDictionary = [NSDictionary dictionaryWithObjects:entities forKeys:ids];
+
+	NSMutableArray *mutableProperties = [NSMutableArray arrayWithArray:properties];
 	[mutableProperties addObject:self.foreignProperty];
-	
-	GDGEntityQuery* query = self.relatedManager.query.select([NSArray arrayWithArray:mutableProperties])
-		.where(^(GDGConditionBuilder *builder) {
-			builder.prop(self.foreignProperty).inList(ids);
-		});
-	
+
+	GDGEntityQuery *query = self.relatedManager.query.select([NSArray arrayWithArray:mutableProperties])
+			.where(^(GDGConditionBuilder *builder) {
+				builder.prop(self.foreignProperty).inList(ids);
+			});
+
 	if (self.condition)
 		query.where(^(GDGConditionBuilder *builder) {
 			builder.and.cat(self.condition);
 		});
-	
-	for (GDGEntity* relatedEntity in query.array)
+
+	for (GDGEntity *relatedEntity in query.array)
 	{
-		GDGEntity* entity = idEntitiesDictionary[[relatedEntity valueForKey:self.foreignProperty]];
+		GDGEntity *entity = idEntitiesDictionary[[relatedEntity valueForKey:self.foreignProperty]];
 		[entity setValue:relatedEntity forKey:self.name];
 	}
 }

--- a/Pod/Classes/GDGJoin.h
+++ b/Pod/Classes/GDGJoin.h
@@ -1,9 +1,8 @@
 //
 //  GDGJoin.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import <Foundation/Foundation.h>
@@ -16,8 +15,8 @@
 @property (strong, readonly, nonatomic) NSString *condition;
 @property (strong, readonly, nonatomic) GDGSource *source;
 
-- (instancetype)initWithType:(NSString*)type condition:(NSString*)condition source:(GDGSource*)source;
+- (instancetype)initWithType:(NSString *)type condition:(NSString *)condition source:(GDGSource *)source;
 
-- (NSString*)visit;
+- (NSString *)visit;
 
 @end

--- a/Pod/Classes/GDGJoin.m
+++ b/Pod/Classes/GDGJoin.m
@@ -1,9 +1,8 @@
 //
 //  GDGJoin.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGJoin.h"
@@ -12,7 +11,7 @@
 
 @implementation GDGJoin
 
-- (instancetype)initWithType:(NSString*)type condition:(NSString*)condition source:(GDGSource*)source
+- (instancetype)initWithType:(NSString *)type condition:(NSString *)condition source:(GDGSource *)source
 {
 	if (self = [super init])
 	{
@@ -20,19 +19,19 @@
 		_condition = condition;
 		_source = source;
 	}
-	
+
 	return self;
 }
 
-- (NSString*)visit
+- (NSString *)visit
 {
-	NSMutableString *joinString = [[NSMutableString alloc] initWithString:_type];
-	
+	NSMutableString *joinString = [_type mutableCopy];
+
 	[joinString appendString:@" JOIN "];
 	[joinString appendString:_source.alias];
 	[joinString appendString:@" ON "];
 	[joinString appendString:_condition];
-	
+
 	return [NSString stringWithString:joinString];
 }
 

--- a/Pod/Classes/GDGQuery.h
+++ b/Pod/Classes/GDGQuery.h
@@ -1,9 +1,8 @@
 //
 //  GDGQuery.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/15/16.
-//
 //
 
 #import <Foundation/Foundation.h>
@@ -11,37 +10,39 @@
 @class GDGConditionBuilder;
 @class GDGSource;
 @class GDGColumn;
-@class GDGEntity;
 
 @interface GDGQuery : NSObject
 
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^select)(NSArray<NSString*>*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^from)(GDGSource*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^fromTable)(NSString*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^join)(__kindof GDGSource*, NSString*, NSString*, NSArray<NSString*>*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^joinTable)(NSString*, NSString*, NSString*, NSArray<NSString*>*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^where)(void (^)(GDGConditionBuilder*));
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^asc)(NSString*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^desc)(NSString*);
-@property (copy, readonly, nonatomic) __kindof GDGQuery* (^limit)(int);
-@property (strong, readonly, nonatomic) NSArray<NSString*>* projection;
-@property (readonly, nonatomic) NSDictionary<NSString*, id>* arguments;
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^select)(NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^from)(GDGSource *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^fromTable)(NSString *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^join)(__kindof GDGSource *, NSString *, NSString *, NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^joinTable)(NSString *, NSString *, NSString *, NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^where)(void (^)(GDGConditionBuilder *));
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^asc)(NSString *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^desc)(NSString *);
+@property (copy, readonly, nonatomic) __kindof GDGQuery *(^limit)(int);
+@property (strong, readonly, nonatomic) NSArray<NSString *> *projection;
+@property (readonly, nonatomic) NSDictionary<NSString *, id> *arguments;
 @property (readonly, nonatomic) GDGConditionBuilder *whereBuilder;
 @property (readonly, nonatomic) GDGSource *source;
 
-- (instancetype)initWithSource:(__kindof GDGSource*)source;
-- (instancetype)initWithTableName:(NSString*)tableName;
+- (instancetype)initWithSource:(__kindof GDGSource *)source;
 
-- (GDGColumn*)findColumnNamed:(NSString*)columnName;
+- (GDGColumn *)findColumnNamed:(NSString *)columnName;
 
-- (NSArray<id>*)pluck;
-- (NSArray<id>*)rawObjects;
-- (NSString*)visit;
+- (NSArray<id> *)pluck;
+
+- (NSArray<id> *)raw;
+
+- (NSString *)visit;
+
 - (NSUInteger)count;
+
 - (instancetype)distinct;
+
 - (instancetype)clearProjection;
+
 - (instancetype)clearOrder;
-- (NSArray<__kindof GDGEntity*>*)array;
-- (__kindof GDGEntity*)object;
 
 @end

--- a/Pod/Classes/GDGQuery.m
+++ b/Pod/Classes/GDGQuery.m
@@ -1,9 +1,8 @@
 //
 //  GDGQuery.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/15/16.
-//
 //
 
 #import "GDGQuery.h"
@@ -15,7 +14,7 @@
 #import "GDGQuery_Protected.h"
 #import "GDGTableSource.h"
 #import "GDGConditionBuilder_Protected.h"
-#import <SQLAid/CIRDatabase.h>
+#import "CIRDatabase+GoldDigger.h"
 #import <SQLAid/CIRResultSet.h>
 #import <ObjectiveSugar/NSArray+ObjectiveSugar.h>
 
@@ -23,7 +22,7 @@
 
 @property (assign, nonatomic) int limitValue;
 @property (assign, nonatomic, getter=isDistinct) BOOL distinctFlag;
-@property (strong, nonatomic) NSMutableArray<GDGJoin*>* joins;
+@property (strong, nonatomic) NSMutableArray<GDGJoin *> *joins;
 
 @end
 
@@ -33,12 +32,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithTableName:(NSString*)tableName
-{
-	return [self initWithSource:[GDGEntityManager tableSourceWithName:tableName]];
-}
-
-- (instancetype)initWithSource:(GDGSource*)source
+- (instancetype)initWithSource:(GDGSource *)source
 {
 	if (self = [super init])
 	{
@@ -46,87 +40,85 @@
 		_conditionBuilder = [[GDGConditionBuilder alloc] init];
 		_mutableProjection = [[NSMutableArray alloc] init];
 
-		__weak __typeof(self)weakSelf = self;
-		
-		_select = ^GDGQuery* (NSArray<NSString*>* projection) {
+		__weak __typeof(self) weakSelf = self;
+
+		_select = ^GDGQuery *(NSArray<NSString *> *projection) {
 			NSMutableArray *validProjection = [[NSMutableArray alloc] initWithCapacity:projection.count];
-			
+
 			for (NSString *columnName in projection)
 			{
 				GDGColumn *column = [weakSelf findColumnNamed:columnName];
 				if (column)
 					[validProjection addObject:column.fullName];
 			}
-			
+
 			[weakSelf.mutableProjection addObjectsFromArray:validProjection];
-			
+
 			return weakSelf;
 		};
-		
-		_join = ^GDGQuery* (GDGSource *joinSource, NSString *type, NSString *condition, NSArray<NSString*>* projection) {
+
+		_join = ^GDGQuery *(GDGSource *joinSource, NSString *type, NSString *condition, NSArray<NSString *> *projection) {
 			if (weakSelf.joins == nil) weakSelf.joins = [[NSMutableArray alloc] init];
-			
+
 			NSMutableArray *validProjection = [[NSMutableArray alloc] initWithCapacity:projection.count];
-			
+
 			for (NSString *column in projection)
 				if ([source columnNamed:column])
 					[validProjection addObject:column];
 
 			weakSelf.select([NSArray arrayWithArray:validProjection]);
-			
+
 			[weakSelf.joins addObject:[[GDGJoin alloc] initWithType:type condition:condition source:source]];
-			
+
 			return weakSelf;
 		};
-		
-		_joinTable = ^GDGQuery* (NSString *tableName, NSString *type, NSString *condition, NSArray<NSString*>* projection) {
-			return weakSelf.join([GDGEntityManager tableSourceWithName:tableName], type, condition, projection);
+
+		_joinTable = ^GDGQuery *(NSString *tableName, NSString *type, NSString *condition, NSArray<NSString *> *projection) {
+			return weakSelf.join([GDGTableSource tableSourceFromTable:tableName in:[CIRDatabase goldDigger_mainDatabase]], type, condition, projection);
 		};
-		
+
 		_where = ^GDGQuery *(void (^handler)(GDGConditionBuilder *)) {
 			handler(weakSelf.conditionBuilder);
 			return weakSelf;
 		};
-		
-		_asc = ^GDGQuery* (NSString* order) {
-			if (weakSelf.orderList == nil) weakSelf.orderList = [[NSMutableArray alloc] init];
-			
-			if ([weakSelf findColumnNamed:order])
-				[weakSelf.orderList addObject:[order stringByAppendingString:@" ASC"]];
-			
-			return weakSelf;
-		};
-		
-		_desc = ^GDGQuery* (NSString* order) {
-			if (weakSelf.orderList == nil) weakSelf.orderList = [[NSMutableArray alloc] init];
-			
-			if ([weakSelf findColumnNamed:order])
-				[weakSelf.orderList addObject:[order stringByAppendingString:@" DESC"]];
-			
-			return weakSelf;
-		};
-		
-		_limit = ^GDGQuery* (int value) {
+
+#define ORDER_BLOCK(direction) \
+        ^GDGQuery *(NSString *col) { \
+            if (weakSelf.orderList == nil)\
+                weakSelf.orderList = [NSMutableArray array];\
+            \
+            if ([weakSelf findColumnNamed:col])\
+                [weakSelf.orderList addObject:[col stringByAppendingString:direction]];\
+            \
+            return weakSelf;\
+        };
+
+		_asc = ORDER_BLOCK(@" ASC");
+		_desc = ORDER_BLOCK(@" DESC");
+
+#undef ORDER_BLOCK
+
+		_limit = ^GDGQuery *(int value) {
 			weakSelf.limitValue = value;
 			return weakSelf;
 		};
-		
-		_from = ^GDGQuery* (GDGSource *fromSource) {
+
+		_from = ^GDGQuery *(GDGSource *fromSource) {
 			weakSelf.source = fromSource;
 			return weakSelf;
 		};
-		
-		_fromTable = ^GDGQuery* (NSString *tableName) {
-			return weakSelf.from([GDGEntityManager tableSourceWithName:tableName]);
+
+		_fromTable = ^GDGQuery *(NSString *tableName) {
+			return weakSelf.from([GDGTableSource tableSourceFromTable:tableName in:[CIRDatabase goldDigger_mainDatabase]]);
 		};
 	}
-	
+
 	return self;
 }
 
-#pragma mark - Others
+#pragma mark - Convenience
 
-- (GDGColumn*)findColumnNamed:(NSString*)columnName
+- (GDGColumn *)findColumnNamed:(NSString *)columnName
 {
 	GDGColumn *column = [_source columnNamed:columnName];
 	if (column == nil)
@@ -135,96 +127,82 @@
 		for (NSUInteger i = 0; i < count && column == nil; i++)
 			column = [_joins[i].source columnNamed:columnName];
 	}
-	
+
 	return column;
 }
 
-#pragma mark - Results
+#pragma mark - Materialization
 
-- (NSString*)visit
+- (NSString *)visit
 {
-	NSMutableString* query = [[NSMutableString alloc] initWithString:@"SELECT "];
-	
+	NSMutableString *query = [[NSMutableString alloc] initWithString:@"SELECT "];
+
 	if (_distinctFlag) [query appendString:@" DISTINCT "];
-	
+
 	[query appendString:_mutableProjection.count > 0 ? @"*" : [_mutableProjection join:@", "]];
-	
+
 	[query appendString:@" FROM "];
 	[query appendString:_source.alias];
-	
+
 	if (_joins.count > 0)
 	{
 		NSString *joinsString = [[_joins map:^id(GDGJoin *object) {
 			return object.visit;
 		}] join:@" "];
-		
+
 		[query appendFormat:@" %@", joinsString];
 	}
-	
-	if (_conditionBuilder)
+
+	if (![_conditionBuilder isEmpty])
 	{
 		[query appendString:@" WHERE ("];
 		[query appendString:_conditionBuilder.visit];
 		[query appendString:@")"];
 	}
-	
+
 	if (_orderList.count > 0)
 	{
 		[query appendString:@" ORDER BY "];
 		[query appendString:[_orderList join:@", "]];
 	}
-	
+
 	if (_limitValue > 0)
 		[query appendFormat:@" LIMIT %d", _limitValue];
-	
+
 	return [NSString stringWithString:query];
 }
 
-- (NSArray<__kindof GDGEntity*>*)array
+- (NSArray *)raw
 {
-	@throw [[NSException alloc] initWithName:@"Unsupported exception" reason:@"Can't build entity." userInfo:nil];
-}
+	NSMutableArray *objects = [NSMutableArray array];
 
-- (__kindof GDGEntity*)object
-{
-	@throw [[NSException alloc] initWithName:@"Unsupported exception" reason:@"Can't build entity." userInfo:nil];
-}
+	CIRResultSet *resultSet = [[CIRDatabase goldDigger_mainDatabase] executeQuery:[self visit] withNamedParameters:self.arguments];
 
-- (NSArray<id>*)rawObjects
-{
-	NSMutableArray<id>* objects = [[NSMutableArray alloc] init];
-	
-	CIRResultSet* resultSet = [[GDGEntityManager database] executeQuery:[self visit] withNamedParameters:self.arguments];
-	
-	while ([resultSet next]) [objects addObject:[self rawObjectWithResultSet:resultSet]];
-	
+	while ([resultSet next])
+		[objects addObject:[self rawObjectWithResultSet:resultSet]];
+
 	return [NSArray arrayWithArray:objects];
 }
 
-- (NSArray<id>*)pluck
+- (NSArray *)pluck
 {
-	NSMutableArray<id>* objects = [[NSMutableArray alloc] init];
-	
 	[_mutableProjection removeObject:@"id"];
-	
-	CIRResultSet* resultSet = [[GDGEntityManager database] executeQuery:[self visit] withNamedParameters:self.arguments];
-	
+
+	NSMutableArray *objects = [NSMutableArray array];
+	CIRResultSet *resultSet = [[CIRDatabase goldDigger_mainDatabase] executeQuery:[self visit] withNamedParameters:self.arguments];
+
+	const int columnCount = [resultSet columnCount];
+
+	for (NSUInteger i = 0; i < columnCount; i++)
+		objects[i] = [NSMutableArray array];
+
 	while ([resultSet next])
-	{
-		int columnCount = [resultSet columnCount];
-		
 		if (columnCount == 1)
 			[objects addObject:resultSet[0]];
 		else
-		{
-			for (int i = 0; i < columnCount; i++)
-				objects[i] = [NSMutableArray array];
-			
-			for (int i = 0; i < columnCount; i++)
+			for (NSUInteger i = 0; i < columnCount; i++)
 				[objects[i] addObject:resultSet[i]];
-		}
-	}
-	
+
 	return [NSArray arrayWithArray:objects];
 }
 
@@ -234,7 +212,32 @@
 	return [self.pluck[0] unsignedIntegerValue];
 }
 
-#pragma mark - Getters & Setters
+#pragma mark Private
+
+- (id)rawObjectWithResultSet:(CIRResultSet *)resultSet
+{
+	id object;
+	const int columnCount = [resultSet columnCount];
+
+	if (columnCount == 0)
+		object = nil;
+	else if (columnCount == 1)
+		object = resultSet[0];
+	else
+	{
+		NSMutableArray *objects = [NSMutableArray array];
+
+		for (NSUInteger i = 0; i < columnCount; i++)
+			[objects addObject:resultSet[i]];
+
+		object = [NSArray arrayWithArray:objects];
+	}
+
+	return object;
+}
+
+#pragma mark - Encaps
+#pragma mark Getter
 
 - (instancetype)distinct
 {
@@ -254,36 +257,14 @@
 	return self;
 }
 
-- (NSArray*)projection
+- (NSArray *)projection
 {
 	return [NSArray arrayWithArray:_mutableProjection];
 }
 
-- (NSDictionary<NSString*, id> *)arguments
+- (NSDictionary<NSString *, id> *)arguments
 {
 	return [_conditionBuilder.arguments copy];
-}
-
-#pragma mark - Private
-
-- (id)rawObjectWithResultSet:(CIRResultSet*)resultSet
-{
-	id object;
-	
-	int columnCount = [resultSet columnCount];
-	
-	if (columnCount == 0) object = nil;
-	else if (columnCount == 1) object = [resultSet objectAtIndex:0];
-	else
-	{
-		NSMutableArray* objects = [[NSMutableArray alloc] init];
-		
-		for (int i = 0; i < columnCount; i++) [objects addObject:[resultSet objectAtIndex:i]];
-		
-		object = [NSArray arrayWithArray:objects];
-	}
-	
-	return object;
 }
 
 @end

--- a/Pod/Classes/GDGQuerySource.h
+++ b/Pod/Classes/GDGQuerySource.h
@@ -1,9 +1,8 @@
 //
 //  GDGQuerySource.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGSource.h"
@@ -14,6 +13,6 @@
 
 @property (strong, nonatomic) GDGQuery *query;
 
-- (instancetype)initWithQuery:(GDGQuery*)query;
+- (instancetype)initWithQuery:(GDGQuery *)query;
 
 @end

--- a/Pod/Classes/GDGQuerySource.m
+++ b/Pod/Classes/GDGQuerySource.m
@@ -1,23 +1,23 @@
 //
 //  GDGQuerySource.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGQuerySource.h"
 
 @implementation GDGQuerySource
 
-- (instancetype)initWithQuery:(GDGQuery*)query;
+- (instancetype)initWithQuery:(GDGQuery *)query;
 {
 	if (self = [super init])
 	{
 		_query = query;
+
 		self.alias = query.source.alias;
 	}
-	
+
 	return self;
 }
 

--- a/Pod/Classes/GDGQuery_Protected.h
+++ b/Pod/Classes/GDGQuery_Protected.h
@@ -1,23 +1,24 @@
 //
 //  GDGQuery_Protected.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/15/16.
-//
 //
 
 #import "GDGQuery.h"
 
 @interface GDGQuery ()
 
-@property (strong, nonatomic) NSMutableArray<NSString*>* mutableProjection;
-@property (strong, nonatomic) NSMutableArray<NSString*>* orderList;
-@property (copy, readwrite, nonatomic) __kindof GDGQuery* (^select)(NSArray<NSString*>*);
-@property (copy, readwrite, nonatomic) __kindof GDGQuery* (^asc)(NSString*);
-@property (copy, readwrite, nonatomic) __kindof GDGQuery* (^desc)(NSString*);
-@property (readwrite, nonatomic) GDGConditionBuilder* conditionBuilder;
+@property (copy, readwrite, nonatomic) __kindof GDGQuery *(^select)(NSArray<NSString *> *);
+@property (copy, readwrite, nonatomic) __kindof GDGQuery *(^asc)(NSString *);
+@property (copy, readwrite, nonatomic) __kindof GDGQuery *(^desc)(NSString *);
+
+@property (strong, nonatomic) NSMutableArray<NSString *> *mutableProjection;
+@property (strong, nonatomic) NSMutableArray<NSString *> *orderList;
+
+@property (readwrite, nonatomic) GDGConditionBuilder *conditionBuilder;
 @property (readwrite, nonatomic) GDGSource *source;
 
-- (NSDictionary<NSString*, id> *)arguments;
+- (NSDictionary<NSString *, id> *)arguments;
 
 @end

--- a/Pod/Classes/GDGRelation.h
+++ b/Pod/Classes/GDGRelation.h
@@ -1,9 +1,8 @@
 //
 //  GDGRelation.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import <Foundation/Foundation.h>
@@ -14,16 +13,16 @@
 
 @interface GDGRelation : NSObject
 
-@property (readonly, nonatomic) NSString* name;
-@property (readonly, nonatomic) GDGEntityManager* manager;
-@property (strong, nonatomic) GDGEntityManager* relatedManager;
-@property (strong, nonatomic) NSString* foreignProperty;
-@property (strong, nonatomic) GDGConditionBuilder* condition;
+@property (readonly, nonatomic) NSString *name;
+@property (readonly, nonatomic) GDGEntityManager *manager;
+@property (strong, nonatomic) GDGEntityManager *relatedManager;
+@property (strong, nonatomic) NSString *foreignProperty;
+@property (strong, nonatomic) GDGConditionBuilder *condition;
 
-- (instancetype)initWithName:(NSString*)name manager:(GDGEntityManager*)manager;
+- (instancetype)initWithName:(NSString *)name manager:(GDGEntityManager *)manager;
 
-- (void)fill:(NSArray<GDGEntity*>*)entities withProperties:(NSArray<NSString*>*)properties;
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties;
 
-- (NSString*)joinCondition;
+- (NSString *)joinCondition;
 
 @end

--- a/Pod/Classes/GDGRelation.m
+++ b/Pod/Classes/GDGRelation.m
@@ -1,50 +1,48 @@
 //
 //  GDGRelation.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import "GDGRelation.h"
 
 #import "GDGEntitySettings.h"
-#import "GDGConditionBuilder.h"
 #import "GDGTableSource.h"
 
 @implementation GDGRelation
 
-- (instancetype)initWithName:(NSString*)name manager:(GDGEntityManager*)manager
+- (instancetype)initWithName:(NSString *)name manager:(GDGEntityManager *)manager
 {
 	if (self = [super init])
 	{
 		_name = name;
 		_manager = manager;
 	}
-	
+
 	return self;
 }
 
 - (void)setRelatedManager:(GDGEntityManager *)relatedManager
 {
 	_relatedManager = relatedManager;
-	
-	NSString* className = [NSStringFromClass(relatedManager.settings.entityClass) substringFromIndex:3];
-	
-	_foreignProperty = [[className stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[[className substringToIndex:1] lowercaseString]] stringByAppendingString:@"Id"];
+
+	NSString *className = [NSStringFromClass(relatedManager.settings.entityClass) substringFromIndex:3];
+
+	_foreignProperty = [[className stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:[[className substringToIndex:1] lowercaseString]] stringByAppendingString:@"Id"];
 }
 
-- (NSString*)joinCondition
+- (NSString *)joinCondition
 {
 	NSMutableString *condition = [[NSMutableString alloc] initWithString:_relatedManager.settings.tableSource.alias];
-	
+
 	[condition appendFormat:@".%@", _foreignProperty];
 	[condition appendFormat:@" = %@.id", _manager.settings.tableSource.alias];
-	
+
 	return [NSString stringWithString:condition];
 }
 
-- (void)fill:(NSArray<GDGEntity*>*)entities withProperties:(NSArray<NSString*>*)properties
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
 {
 	@throw [[NSException alloc] initWithName:@"Not Implemented" reason:@"TODO" userInfo:nil];
 }

--- a/Pod/Classes/GDGSource.h
+++ b/Pod/Classes/GDGSource.h
@@ -1,9 +1,8 @@
 //
 //  GDGSource.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import <Foundation/Foundation.h>
@@ -20,8 +19,6 @@
 - (NSString *)adjustColumnNamed:(NSString *)columnName;
 
 - (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
-
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)idx;
 
 @end
 

--- a/Pod/Classes/GDGSource.m
+++ b/Pod/Classes/GDGSource.m
@@ -1,9 +1,8 @@
 //
 //  GDGSource.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGSource.h"
@@ -17,41 +16,36 @@
 {
 	for (GDGColumn *column in columns)
 		column.source = self;
-	
+
 	_columns = columns;
 }
 
-- (GDGColumn*)columnNamed:(NSString*)columnName
+- (GDGColumn *)columnNamed:(NSString *)columnName
 {
 	columnName = [self adjustColumnNamed:columnName];
-	
-	NSInteger dotIndex = [columnName rangeOfString:@"."].location;
-	
+
+	NSUInteger dotIndex = [columnName rangeOfString:@"."].location;
+
 	NSString *sourceName = [columnName substringToIndex:dotIndex];
 	NSString *columnRealName = [columnName substringFromIndex:dotIndex + 1];
 
 	BOOL isSameSource = [self.alias caseInsensitiveCompare:sourceName] == NSOrderedSame;
 	GDGColumn *column = [self.columns detect:^BOOL(id object) {
-		return [((GDGColumn*) object).name caseInsensitiveCompare:columnRealName] == NSOrderedSame;
+		return [((GDGColumn *) object).name caseInsensitiveCompare:columnRealName] == NSOrderedSame;
 	}];
 
 	return isSameSource ? column : nil;
 }
 
-- (NSString*)adjustColumnNamed:(NSString*)columnName
+- (NSString *)adjustColumnNamed:(NSString *)columnName
 {
 	NSInteger dotIndex = [columnName rangeOfString:@"."].location;
 	return dotIndex != NSNotFound ? columnName : [_alias stringByAppendingFormat:@".%@", columnName];
 }
 
-- (GDGColumn*)objectForKeyedSubscript:(NSString*)idx
+- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx
 {
 	return [self columnNamed:idx];
-}
-
-- (void)setObject:(id)obj forKeyedSubscript:(NSString*)idx
-{
-	@throw [NSException exceptionWithName:@"Unsupported exception" reason:@"Can't set a column object" userInfo:nil];
 }
 
 @end

--- a/Pod/Classes/GDGSource_Protected.h
+++ b/Pod/Classes/GDGSource_Protected.h
@@ -1,5 +1,8 @@
 //
-// Created by Pietro Caselani on 2/26/16.
+//  GDGTableSource.h
+//  GoldDigger
+//
+//  Created by Pietro Caselani on 2/26/16.
 //
 
 #import <Foundation/Foundation.h>
@@ -8,6 +11,6 @@
 
 @interface GDGSource ()
 
-@property(readwrite, nonatomic) NSArray<GDGColumn *> *columns;
+@property (readwrite, nonatomic) NSArray<GDGColumn *> *columns;
 
 @end

--- a/Pod/Classes/GDGTableSource.h
+++ b/Pod/Classes/GDGTableSource.h
@@ -1,19 +1,23 @@
 //
 //  GDGTableSource.h
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
-//
 //
 
 #import "GDGSource.h"
 
 @class GDGColumn;
+@class CIRDatabase;
 
 @interface GDGTableSource : GDGSource
 
-@property (strong, readonly, nonatomic) NSString* name;
+@property (strong, readonly, nonatomic) NSString *name;
 
-- (instancetype)initWithName:(NSString*)tableName columns:(NSArray<GDGColumn*>*)columns;
++ (instancetype)tableSourceFromTable:(NSString *)tableName;
+
++ (instancetype)tableSourceFromTable:(NSString *)tableName in:(CIRDatabase *)database;
+
+- (instancetype)initWithName:(NSString *)tableName columns:(NSArray<GDGColumn *> *)columns;
 
 @end

--- a/Pod/Classes/GDGTableSource.m
+++ b/Pod/Classes/GDGTableSource.m
@@ -1,25 +1,51 @@
 //
 //  GDGTableSource.m
-//  Pods
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 2/12/16.
 //
-//
 
+#import <SQLAid/CIRDatabase.h>
 #import "GDGTableSource.h"
 
 #import "GDGSource_Protected.h"
+#import "CIRResultSet.h"
+#import "CIRDatabase+GoldDigger.h"
 
 @implementation GDGTableSource
 
-- (instancetype)initWithName:(NSString*)tableName columns:(NSArray<GDGColumn*>*)columns
++ (instancetype)tableSourceFromTable:(NSString *)tableName
+{
+	return [self tableSourceFromTable:tableName in:[CIRDatabase goldDigger_mainDatabase]];
+}
+
++ (instancetype)tableSourceFromTable:(NSString *)tableName in:(CIRDatabase *)database
+{
+	CIRResultSet *resultSet = [database executeQuery:[NSString stringWithFormat:@"PRAGMA table_info(%@)", tableName]];
+
+	NSMutableArray<GDGColumn *> *columns = [[NSMutableArray alloc] init];
+
+	while ([resultSet next])
+	{
+		NSString *name = [resultSet textAtIndex:1];
+		GDGColumnType type = [GDGColumn columnTypeFromTypeName:[resultSet textAtIndex:2]];
+		BOOL notNull = [resultSet boolAtIndex:3];
+		BOOL primaryKey = [resultSet boolAtIndex:5];
+
+		[columns addObject:[[GDGColumn alloc] initWithName:name type:type primaryKey:primaryKey notNull:notNull]];
+	}
+
+	return [[GDGTableSource alloc] initWithName:tableName columns:[NSArray arrayWithArray:columns]];
+}
+
+- (instancetype)initWithName:(NSString *)tableName columns:(NSArray<GDGColumn *> *)columns
 {
 	if (self = [super init])
 	{
 		self.alias = _name = tableName;
 		self.columns = columns;
 	}
-	
+
 	return self;
 }
 

--- a/Pod/Classes/GDGValueTransformer.h
+++ b/Pod/Classes/GDGValueTransformer.h
@@ -1,17 +1,18 @@
 //
-//  GDGValueAdapter.h
-//  Pods
+//  GDGValueTransformer.h
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
-//
 //
 
 #import <Foundation/Foundation.h>
 
-@interface GDGValueAdapter : NSValueTransformer
+@interface GDGValueTransformer : NSValueTransformer
 
 @property (copy, nonatomic) id (^fromDatabase)(id);
 @property (copy, nonatomic) id (^toDatabase)(id);
+
++ (instancetype)transformerFrom:(id (^)(id))fromDatabaseHandler to:(id (^)(id))toDatabaseHandler;
 
 - (instancetype)initWithFromDatabaseHandler:(id (^)(id))fromDatabaseHandler toDatabaseHandler:(id (^)(id))toDatabaseHandler;
 

--- a/Pod/Classes/GDGValueTransformer.m
+++ b/Pod/Classes/GDGValueTransformer.m
@@ -1,18 +1,22 @@
 //
-//  GDGValueAdapter.m
-//  Pods
+//  GDGValueTransformer.m
+//  GoldDigger
 //
 //  Created by Pietro Caselani on 1/26/16.
 //
-//
 
-#import "GDGValueAdapter.h"
+#import "GDGValueTransformer.h"
 
-@implementation GDGValueAdapter
+@implementation GDGValueTransformer
 
 + (BOOL)allowsReverseTransformation
 {
 	return YES;
+}
+
++ (instancetype)transformerFrom:(id (^)(id))fromDatabaseHandler to:(id (^)(id))toDatabaseHandler
+{
+	return [[self alloc] initWithFromDatabaseHandler:fromDatabaseHandler toDatabaseHandler:toDatabaseHandler];
 }
 
 - (instancetype)initWithFromDatabaseHandler:(id (^)(id))fromDatabaseHandler toDatabaseHandler:(id (^)(id))toDatabaseHandler
@@ -22,7 +26,7 @@
 		_toDatabase = toDatabaseHandler;
 		_fromDatabase = fromDatabaseHandler;
 	}
-	
+
 	return self;
 }
 


### PR DESCRIPTION
Fixes headers removing copyright, identating with the project standar, renaming with the correct project title, etc... 
Idents all files equaly, using ours (CopyIsRight) AppCode configuration. 
Renames `GDGValueAdapter` to `GDGValueTransformer`, because we are not developing in Java.
Remove unused methods, fix type missuse warnings, rename some misspelling variables...
And finally remove `GDGEntityManager`'s database (look at `CIRDatabase+GoldDigger` for more information)

@pietrocaselani be my guest
