### PR TITLE
Inequality and context

### DIFF
--- a/Pod/Classes/GDGConditionBuilder+EntityQuery.m
+++ b/Pod/Classes/GDGConditionBuilder+EntityQuery.m
@@ -39,11 +39,7 @@
 		__weak typeof(self) weakSelf = self;
 
 		prop = ^GDGConditionBuilder *(NSString *property) {
-			GDGEntityQuery *query = weakSelf.query;
-
-			NSInteger dotIndex = [property rangeOfString:@"."].location;
-
-			return weakSelf.col([query.manager columnForProperty:dotIndex == NSNotFound ? property : [property substringFromIndex:(NSUInteger) (dotIndex + 1)]]);
+			return weakSelf.col([weakSelf.query.manager columnForProperty:property]);
 		};
 
 		objc_setAssociatedObject(self, _cmd, prop, OBJC_ASSOCIATION_COPY_NONATOMIC);

--- a/Pod/Classes/GDGConditionBuilder.h
+++ b/Pod/Classes/GDGConditionBuilder.h
@@ -15,15 +15,20 @@
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^build)(void (^)(GDGConditionBuilder *));
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^col)(GDGColumn *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^cat)(GDGConditionBuilder *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^func)(NSString *, NSArray<GDGColumn *> *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^equals)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^gt)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^gte)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^lt)(id);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^lte)(id);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^notEquals)(id);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^isNull)();
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^isNotNull)();
-@property (copy, readonly, nonatomic) GDGConditionBuilder *(^equalsDate)(NSString *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^equalsCol)(GDGColumn *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^inText)(NSString *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^inList)(NSArray<NSNumber *> *);
 @property (copy, readonly, nonatomic) GDGConditionBuilder *(^inQuery)(GDGQuery *);
+@property (copy, readonly, nonatomic) GDGConditionBuilder *(^DATE)(GDGColumn *);
 
 + (instancetype)builder;
 

--- a/Pod/Classes/GDGEntity.h
+++ b/Pod/Classes/GDGEntity.h
@@ -9,6 +9,7 @@
 
 @class GDGEntityManager;
 @class GDGEntity;
+@class GDGColumn;
 
 @protocol GDGEntityFillDelegate <NSObject>
 

--- a/Pod/Classes/GDGEntityManager.h
+++ b/Pod/Classes/GDGEntityManager.h
@@ -53,4 +53,6 @@
 
 - (void)addValueTransformer:(__kindof NSValueTransformer *)transformer forProperties:(NSArray<NSString *> *)properties;
 
+- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
+
 @end

--- a/Pod/Classes/GDGEntityManager.m
+++ b/Pod/Classes/GDGEntityManager.m
@@ -400,4 +400,11 @@ static NSMutableDictionary<NSString *, GDGEntitySettings *> *ClassSettingsDictio
 	return [NSString stringWithFormat:@"DELETE FROM %@ WHERE id = ?", _settings.tableSource.alias];
 }
 
+#pragma mark - Subscript
+
+- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx
+{
+	return [self columnForProperty:idx];
+}
+
 @end

--- a/Pod/Classes/GDGQuery.m
+++ b/Pod/Classes/GDGQuery.m
@@ -40,7 +40,7 @@
 		_conditionBuilder = [[GDGConditionBuilder alloc] init];
 		_mutableProjection = [[NSMutableArray alloc] init];
 
-		__weak __typeof(self) weakSelf = self;
+		__weak typeof(self) weakSelf = self;
 
 		_select = ^GDGQuery *(NSArray<NSString *> *projection) {
 			NSMutableArray *validProjection = [[NSMutableArray alloc] initWithCapacity:projection.count];
@@ -139,7 +139,7 @@
 
 	if (_distinctFlag) [query appendString:@" DISTINCT "];
 
-	[query appendString:_mutableProjection.count > 0 ? @"*" : [_mutableProjection join:@", "]];
+	[query appendString:_mutableProjection.count == 0 ? @"*" : [_mutableProjection join:@", "]];
 
 	[query appendString:@" FROM "];
 	[query appendString:_source.alias];
@@ -193,7 +193,7 @@
 
 	const int columnCount = [resultSet columnCount];
 
-	for (NSUInteger i = 0; i < columnCount; i++)
+	for (NSUInteger i = 0; i < columnCount && columnCount > 1; i++)
 		objects[i] = [NSMutableArray array];
 
 	while ([resultSet next])


### PR DESCRIPTION
This is one for _version release_.

What does it does?
- Adds inequality operators (`<`, `>`, `<=`, `>=`) to `GDGConditionBuilder`
- Adds `context` as a way of _keeping track_ of what has been added previous to an operation
- Fixes the `GDGQuery` bug that was always exchanging query's projection with `*` but when it is _empty_
- Fixes a bug at `-pluck` `GDGQuery`'s method, which was assembling the result array amiss
- Adds convenience _keyed subscript_ method to GDGEntityManager

And last but not least
- Adds expression/function definitions as a context in `GDGConditionBuild`

Of course, there were some other little improvements, always including code removal :tada: 
