### PR TITLE
Small adjustments

### DIFF
--- a/Pod/Classes/GDGBelongsToRelation.m
+++ b/Pod/Classes/GDGBelongsToRelation.m
@@ -55,7 +55,7 @@
 	}
 }
 
-- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource
+- (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource
 {
 	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
 

--- a/Pod/Classes/GDGBelongsToRelation.m
+++ b/Pod/Classes/GDGBelongsToRelation.m
@@ -38,9 +38,9 @@
 	}
 
 	GDGEntityQuery *query = self.relatedManager.query.select(properties)
-			.where(^(GDGCondition *builder) {
-				builder.prop(@"id").inList(ids);
-			});
+		.where(^(GDGCondition *builder) {
+			builder.prop(@"id").inList(ids);
+		});
 
 	if (self.condition)
 		query.where(^(GDGCondition *builder) {
@@ -55,12 +55,11 @@
 	}
 }
 
-- (NSString *)joinCondition
+- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource
 {
-	NSMutableString *condition = [[NSMutableString alloc] initWithString:self.manager.settings.tableSource.alias];
+	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
 
-	[condition appendString:@".id"];
-	[condition appendFormat:@" = %@.%@", self.relatedManager.settings.tableSource.alias, self.foreignProperty];
+	[condition appendFormat:@".%@ = %@.id", [self.manager columnNameForProperty:self.foreignProperty], source.identifier];
 
 	return [NSString stringWithString:condition];
 }

--- a/Pod/Classes/GDGColumn.m
+++ b/Pod/Classes/GDGColumn.m
@@ -54,7 +54,7 @@
 
 - (NSString *)fullName
 {
-	return [self.source.alias stringByAppendingFormat:@".%@", _name];
+	return [(self.source.alias ? self.source.alias : self.source.name) stringByAppendingFormat:@".%@", _name];
 }
 
 - (GDGColumn *)copyWithZone:(nullable NSZone *)zone

--- a/Pod/Classes/GDGColumn.m
+++ b/Pod/Classes/GDGColumn.m
@@ -54,7 +54,7 @@
 
 - (NSString *)fullName
 {
-	return [(self.source.alias ? self.source.alias : self.source.name) stringByAppendingFormat:@".%@", _name];
+	return [self.source.identifier stringByAppendingFormat:@".%@", _name];
 }
 
 - (GDGColumn *)copyWithZone:(nullable NSZone *)zone

--- a/Pod/Classes/GDGCondition.h
+++ b/Pod/Classes/GDGCondition.h
@@ -24,7 +24,6 @@
 @property (copy, readonly, nonatomic) GDGCondition *(^notEquals)(id);
 @property (copy, readonly, nonatomic) GDGCondition *(^isNull)();
 @property (copy, readonly, nonatomic) GDGCondition *(^isNotNull)();
-@property (copy, readonly, nonatomic) GDGCondition *(^equalsCol)(GDGColumn *);
 @property (copy, readonly, nonatomic) GDGCondition *(^inText)(NSString *);
 @property (copy, readonly, nonatomic) GDGCondition *(^inList)(NSArray<NSNumber *> *);
 @property (copy, readonly, nonatomic) GDGCondition *(^inQuery)(GDGQuery *);

--- a/Pod/Classes/GDGCondition.m
+++ b/Pod/Classes/GDGCondition.m
@@ -111,7 +111,7 @@
 
 		_cat = ^GDGCondition *(GDGCondition *builder) {
 			[weakSelf.args addEntriesFromDictionary:builder.args];
-			return [[weakSelf and] appendText:builder.visit];
+			return [weakSelf appendText:builder.visit];
 		};
 
 		_inQuery = ^GDGCondition *(GDGQuery *query) {

--- a/Pod/Classes/GDGCondition.m
+++ b/Pod/Classes/GDGCondition.m
@@ -57,7 +57,12 @@
 		};
 
 		_equals = ^GDGCondition *(id value) {
-			return [weakSelf appendValue:value forOperator:@"="];
+			if ([value isKindOfClass:[GDGColumn class]])
+				[weakSelf appendText:[NSString stringWithFormat:@"= %@", [value fullName]]];
+			else
+				[weakSelf appendValue:value forOperator:@"="];
+
+			return weakSelf;
 		};
 
 		_gt = ^GDGCondition *(id value) {
@@ -90,11 +95,6 @@
 
 		_isNotNull = ^GDGCondition * {
 			return [weakSelf appendText:@"IS NOT NULL"];
-		};
-
-		_equalsCol = ^GDGCondition *(GDGColumn *column) {
-			[weakSelf appendText:[NSString stringWithFormat:@"= %@", column.fullName]];
-			return weakSelf;
 		};
 
 		_inText = ^GDGCondition *(NSString *text) {

--- a/Pod/Classes/GDGCondition.m
+++ b/Pod/Classes/GDGCondition.m
@@ -93,7 +93,7 @@
 		};
 
 		_equalsCol = ^GDGCondition *(GDGColumn *column) {
-			[weakSelf appendValue:column.fullName forOperator:@"="];
+			[weakSelf appendText:[NSString stringWithFormat:@"= %@", column.fullName]];
 			return weakSelf;
 		};
 
@@ -196,7 +196,7 @@
 
 - (GDGCondition *)appendText:(NSString *)text
 {
-	[_strings addObject:[NSString stringWithFormat:@"%@", text]];
+	[_strings addObject:text];
 
 	return self;
 }

--- a/Pod/Classes/GDGEntityManager.h
+++ b/Pod/Classes/GDGEntityManager.h
@@ -54,7 +54,7 @@
 
 - (void)addValueTransformer:(__kindof NSValueTransformer *)transformer forProperties:(NSArray<NSString *> *)properties;
 
-- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
+- (id)objectForKeyedSubscript:(NSString *)idx;
 
 - (GDGRelation *)relationNamed:(NSString *)relationName;
 

--- a/Pod/Classes/GDGEntityManager.h
+++ b/Pod/Classes/GDGEntityManager.h
@@ -15,6 +15,7 @@
 @class GDGTableSource;
 @class CIRDatabase;
 @class GDGColumn;
+@class GDGRelation;
 
 @interface GDGEntityManager : NSObject <GDGEntityFillDelegate>
 
@@ -54,5 +55,7 @@
 - (void)addValueTransformer:(__kindof NSValueTransformer *)transformer forProperties:(NSArray<NSString *> *)properties;
 
 - (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
+
+- (GDGRelation *)relationNamed:(NSString *)relationName;
 
 @end

--- a/Pod/Classes/GDGEntityManager.m
+++ b/Pod/Classes/GDGEntityManager.m
@@ -406,9 +406,10 @@ static NSMutableDictionary<NSString *, GDGEntitySettings *> *ClassSettingsDictio
 
 #pragma mark - Subscript
 
-- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx
+- (id)objectForKeyedSubscript:(NSString *)idx;
 {
-	return [self columnForProperty:idx];
+	GDGColumn *column = [self columnForProperty:idx];
+	return column ?: [self relationNamed:idx];
 }
 
 @end

--- a/Pod/Classes/GDGEntityManager.m
+++ b/Pod/Classes/GDGEntityManager.m
@@ -10,7 +10,7 @@
 #import "GDGBelongsToRelation.h"
 #import "GDGColumn.h"
 #import "GDGEntityQuery.h"
-#import "GDGEntitySettings_Relations.h"
+#import "GDGEntitySettings+Relations.h"
 #import "GDGHasManyRelation.h"
 #import "GDGHasOneRelation.h"
 #import "GDGTableSource.h"
@@ -344,6 +344,11 @@ static NSMutableDictionary<NSString *, GDGEntitySettings *> *ClassSettingsDictio
 - (GDGColumn *)columnForProperty:(NSString *)propertyName
 {
 	return _settings.tableSource[[self columnNameForProperty:propertyName]];
+}
+
+- (GDGRelation *)relationNamed:(NSString *)relationName
+{
+	return _settings.relationNameDictionary[relationName];
 }
 
 #pragma mark - Adapters

--- a/Pod/Classes/GDGEntityQuery.m
+++ b/Pod/Classes/GDGEntityQuery.m
@@ -11,7 +11,7 @@
 #import "GDGColumn.h"
 #import "GDGEntityManager.h"
 #import "GDGEntitySettings.h"
-#import "GDGEntitySettings_Relations.h"
+#import "GDGEntitySettings+Relations.h"
 #import "GDGQuery_Protected.h"
 #import "GDGRelation.h"
 #import "GDGTableSource.h"

--- a/Pod/Classes/GDGEntityQuery.m
+++ b/Pod/Classes/GDGEntityQuery.m
@@ -77,10 +77,11 @@
       if (weakSelf.orderList == nil)\
         weakSelf.orderList = [NSMutableArray array];\
       \
-      NSString *column = [weakSelf.manager columnNameForProperty:prop]; \
+      NSString *columnName = [weakSelf.manager columnNameForProperty:prop]; \
+			GDGColumn *column; \
       \
-      if ([weakSelf findColumnNamed:column])\
-        [weakSelf.orderList addObject:[column stringByAppendingString:direction]];\
+      if (column = [weakSelf findColumnNamed:columnName])\
+        [weakSelf.orderList addObject:[column.fullName stringByAppendingString:direction]];\
       \
       return weakSelf;\
     };

--- a/Pod/Classes/GDGEntitySettings+Relations.h
+++ b/Pod/Classes/GDGEntitySettings+Relations.h
@@ -1,13 +1,13 @@
 //
-//  GDGEntitySettings_Relations.h
-//  GoldDigger
+//  GDGEntitySettings+Relations.h
+//  Pods
 //
-//  Created by Pietro Caselani on 1/26/16.
+//  Created by Pietro Caselani on 3/14/16.
 //
 
 #import "GDGEntitySettings.h"
 
-@interface GDGEntitySettings ()
+@interface GDGEntitySettings (Relations)
 
 @property (strong, nonatomic) NSMutableDictionary<NSString *, GDGRelation *> *relationNameDictionary;
 @property (strong, nonatomic) NSMutableDictionary<NSString *, NSValueTransformer *> *valueTransformerDictionary;

--- a/Pod/Classes/GDGEntitySettings+Relations.m
+++ b/Pod/Classes/GDGEntitySettings+Relations.m
@@ -1,0 +1,34 @@
+//
+//  GDGEntitySettings+Relations.m
+//  Pods
+//
+//  Created by Pietro Caselani on 3/14/16.
+//
+
+#import "GDGEntitySettings+Relations.h"
+
+#import <objc/runtime.h>
+
+@implementation GDGEntitySettings (Relations)
+
+- (NSMutableDictionary *)relationNameDictionary
+{
+	return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setRelationNameDictionary:(NSMutableDictionary *)relationNameDictionary
+{
+	objc_setAssociatedObject(self, @selector(relationNameDictionary), relationNameDictionary, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSMutableDictionary *)valueTransformerDictionary
+{
+	return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setValueTransformerDictionary:(NSMutableDictionary *)valueTransformerDictionary
+{
+	objc_setAssociatedObject(self, @selector(valueTransformerDictionary), valueTransformerDictionary, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end

--- a/Pod/Classes/GDGEntitySettings.m
+++ b/Pod/Classes/GDGEntitySettings.m
@@ -8,9 +8,12 @@
 #import "GDGEntitySettings.h"
 
 #import "GDGEntitySettings+Relations.h"
+#import "GDGTableSource.h"
 #import <objc/runtime.h>
 
 @implementation GDGEntitySettings
+
+@synthesize tableSource = _tableSource;
 
 - (instancetype)initWithEntityClass:(Class)entityClass tableSource:(GDGTableSource *)tableSource
 {
@@ -39,5 +42,11 @@
 
 	_propertiesDictionary = propertiesDictionary;
 }
+
+- (GDGTableSource *)tableSource
+{
+	return _tableSource.copy;
+}
+
 
 @end

--- a/Pod/Classes/GDGEntitySettings.m
+++ b/Pod/Classes/GDGEntitySettings.m
@@ -7,7 +7,7 @@
 
 #import "GDGEntitySettings.h"
 
-#import "GDGEntitySettings_Relations.h"
+#import "GDGEntitySettings+Relations.h"
 #import <objc/runtime.h>
 
 @implementation GDGEntitySettings
@@ -18,8 +18,8 @@
 	{
 		_entityClass = entityClass;
 		_tableSource = tableSource;
-		_relationNameDictionary = [NSMutableDictionary dictionary];
-		_valueTransformerDictionary = [NSMutableDictionary dictionary];
+		self.relationNameDictionary = [NSMutableDictionary dictionary];
+		self.valueTransformerDictionary = [NSMutableDictionary dictionary];
 	}
 
 	return self;

--- a/Pod/Classes/GDGJoin.m
+++ b/Pod/Classes/GDGJoin.m
@@ -28,7 +28,11 @@
 	NSMutableString *joinString = [_type mutableCopy];
 
 	[joinString appendString:@" JOIN "];
-	[joinString appendString:_source.alias];
+	[joinString appendString:_source.name];
+
+	if (_source.alias)
+		[joinString appendFormat:@" AS %@", _source.alias];
+
 	[joinString appendString:@" ON "];
 	[joinString appendString:_condition];
 

--- a/Pod/Classes/GDGQuery.m
+++ b/Pod/Classes/GDGQuery.m
@@ -165,7 +165,10 @@
 	[query appendString:_mutableProjection.count == 0 ? @"*" : [_mutableProjection join:@", "]];
 
 	[query appendString:@" FROM "];
-	[query appendString:_source.alias];
+	[query appendString:_source.name];
+
+	if (_source.alias)
+		[query appendFormat:@" AS %@", _source.alias];
 
 	if (_joins.count > 0)
 	{

--- a/Pod/Classes/GDGQuery.m
+++ b/Pod/Classes/GDGQuery.m
@@ -103,8 +103,9 @@
             if (weakSelf.orderList == nil)\
                 weakSelf.orderList = [NSMutableArray array];\
             \
-            if ([weakSelf findColumnNamed:col])\
-                [weakSelf.orderList addObject:[col stringByAppendingString:direction]];\
+						GDGColumn *column; \
+            if (column = [weakSelf findColumnNamed:col])\
+                [weakSelf.orderList addObject:[column.fullName stringByAppendingString:direction]];\
             \
             return weakSelf;\
         };

--- a/Pod/Classes/GDGRelation.h
+++ b/Pod/Classes/GDGRelation.h
@@ -10,6 +10,7 @@
 #import "GDGEntityManager.h"
 
 @class GDGCondition;
+@class GDGSource;
 
 @interface GDGRelation : NSObject
 
@@ -24,5 +25,7 @@
 - (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties;
 
 - (NSString *)joinCondition;
+
+- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource;
 
 @end

--- a/Pod/Classes/GDGRelation.h
+++ b/Pod/Classes/GDGRelation.h
@@ -26,6 +26,6 @@
 
 - (NSString *)joinCondition;
 
-- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource;
+- (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource;
 
 @end

--- a/Pod/Classes/GDGRelation.m
+++ b/Pod/Classes/GDGRelation.m
@@ -9,6 +9,7 @@
 
 #import "GDGEntitySettings.h"
 #import "GDGTableSource.h"
+#import "GDGSource.h"
 
 @implementation GDGRelation
 
@@ -34,10 +35,14 @@
 
 - (NSString *)joinCondition
 {
-	NSMutableString *condition = [[NSMutableString alloc] initWithString:_relatedManager.settings.tableSource.alias];
+	return [self joinConditionForSource:_manager.settings.tableSource withSource:_relatedManager.settings.tableSource];
+}
 
-	[condition appendFormat:@".%@", _foreignProperty];
-	[condition appendFormat:@" = %@.id", _manager.settings.tableSource.alias];
+- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource
+{
+	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
+
+	[condition appendFormat:@".id = %@.%@", source.identifier, [_manager columnNameForProperty:_foreignProperty]];
 
 	return [NSString stringWithString:condition];
 }

--- a/Pod/Classes/GDGRelation.m
+++ b/Pod/Classes/GDGRelation.m
@@ -35,10 +35,10 @@
 
 - (NSString *)joinCondition
 {
-	return [self joinConditionForSource:_manager.settings.tableSource withSource:_relatedManager.settings.tableSource];
+	return [self joinConditionFromSource:_manager.settings.tableSource toSource:_relatedManager.settings.tableSource];
 }
 
-- (NSString *)joinConditionForSource:(GDGSource *)source withSource:(GDGSource *)joinedSource
+- (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource
 {
 	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
 

--- a/Pod/Classes/GDGSource.h
+++ b/Pod/Classes/GDGSource.h
@@ -11,6 +11,7 @@
 
 @interface GDGSource : NSObject <NSCopying>
 
+@property (strong, nonatomic) NSString *name;
 @property (strong, nonatomic) NSString *alias;
 @property (readonly, nonatomic) NSArray<GDGColumn *> *columns;
 
@@ -19,6 +20,8 @@
 - (NSString *)adjustColumnNamed:(NSString *)columnName;
 
 - (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
+
+- (NSString *)identifier;
 
 @end
 

--- a/Pod/Classes/GDGSource.m
+++ b/Pod/Classes/GDGSource.m
@@ -41,7 +41,7 @@
 - (NSString *)adjustColumnNamed:(NSString *)columnName
 {
 	NSInteger dotIndex = [columnName rangeOfString:@"."].location;
-	return dotIndex != NSNotFound ? columnName : [_alias stringByAppendingFormat:@".%@", columnName];
+	return dotIndex != NSNotFound ? columnName : [self.identifier stringByAppendingFormat:@".%@", columnName];
 }
 
 - (GDGColumn *)objectForKeyedSubscript:(NSString *)idx
@@ -49,11 +49,17 @@
 	return [self columnNamed:idx];
 }
 
+- (NSString *)identifier
+{
+	return _alias ? _alias : _name;
+}
+
 - (__kindof GDGSource *)copyWithZone:(nullable NSZone *)zone
 {
 	GDGSource *copy = (GDGSource *) [[[self class] allocWithZone:zone] init];
 
 	copy.alias = _alias;
+	copy.name = _name;
 	copy.columns = [_columns copy];
 
 	return copy;

--- a/Pod/Classes/GDGSource.m
+++ b/Pod/Classes/GDGSource.m
@@ -51,7 +51,7 @@
 
 - (NSString *)identifier
 {
-	return _alias ? _alias : _name;
+	return _alias ?: _name;
 }
 
 - (__kindof GDGSource *)copyWithZone:(nullable NSZone *)zone

--- a/Pod/Classes/GDGTableSource.h
+++ b/Pod/Classes/GDGTableSource.h
@@ -12,12 +12,12 @@
 
 @interface GDGTableSource : GDGSource <NSCopying>
 
-@property (readonly, nonatomic) NSString *name;
-
 + (instancetype)tableSourceFromTable:(NSString *)tableName;
 
 + (instancetype)tableSourceFromTable:(NSString *)tableName in:(CIRDatabase *)database;
 
 - (instancetype)initWithName:(NSString *)tableName columns:(NSArray<GDGColumn *> *)columns;
+
+- (GDGColumn *)objectForKeyedSubscript:(NSString *)idx;
 
 @end

--- a/Pod/Classes/GDGTableSource.m
+++ b/Pod/Classes/GDGTableSource.m
@@ -12,12 +12,6 @@
 #import "CIRResultSet.h"
 #import "CIRDatabase+GoldDigger.h"
 
-@interface GDGTableSource ()
-
-@property (readwrite, nonatomic) NSString *name;
-
-@end
-
 @implementation GDGTableSource
 
 + (instancetype)tableSourceFromTable:(NSString *)tableName
@@ -48,7 +42,7 @@
 {
 	if (self = [super init])
 	{
-		self.alias = _name = tableName;
+		self.name = tableName;
 		self.columns = columns;
 	}
 
@@ -57,9 +51,7 @@
 
 - (GDGTableSource *)copyWithZone:(nullable NSZone *)zone
 {
-	GDGTableSource *copy = (GDGTableSource *) [super copyWithZone:zone];
-	copy.name = _name;
-	return copy;
+	return (GDGTableSource *) [super copyWithZone:zone];
 }
 
 @end


### PR DESCRIPTION
- Fix `GDGEntitySettings+Relations` properties;
- Remove the `and` on `GDGCondition.cat`;
- Add the method `relationNamed:` on `GDGEntityManager`;
- Add `identifier` property on `GDGSource` that returns the name or alias;
- Fix `GDGCondition.equalsCol`;
- Add on `GDGRelation*` the method `joinCondition` with two sources;
- Fix the `visit` method on `GDGJoin`;
- `GDGEntitySettings` always returns a copy from the `tableSource`.
