### PR TITLE
Relation loading, saving and pulling and other additions

### DIFF
--- a/Pod/Classes/GDGBelongsToRelation.m
+++ b/Pod/Classes/GDGBelongsToRelation.m
@@ -15,17 +15,29 @@
 
 @implementation GDGBelongsToRelation
 
-- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
+- (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource
 {
-	NSArray<NSNumber *> *ids = [entities map:^id(id object) {
-		return [object valueForKey:self.foreignProperty];
+	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
+
+	[condition appendFormat:@".%@ = %@.id", [self.manager columnNameForProperty:self.foreignProperty], source.identifier];
+
+	return [NSString stringWithString:condition];
+}
+
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray *)properties
+{
+	NSArray *ids = [entities map:^id(id object) {
+		return [object valueForKey:self.foreignProperty] ?: [NSNull null];
 	}];
 
 	NSMutableDictionary<NSNumber *, NSMutableArray<GDGEntity *> *> *relationEntitiesDictionary = [[NSMutableDictionary alloc] initWithCapacity:entities.count];
 	for (NSUInteger i = 0; i < entities.count; i++)
 	{
+		id foreignId = ids[i];
+		if (foreignId == [NSNull null])
+			continue;
+
 		GDGEntity *entity = entities[i];
-		NSNumber *foreignId = ids[i];
 
 		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[foreignId];
 		if (mutableEntities == nil)
@@ -37,31 +49,48 @@
 		[mutableEntities addObject:entity];
 	}
 
-	GDGEntityQuery *query = self.relatedManager.query.select(properties)
-		.where(^(GDGCondition *builder) {
-			builder.prop(@"id").inList(ids);
-		});
+	ids = [ids select:^BOOL(id object) {
+		return object != [NSNull null];
+	}];
+
+	GDGEntityQuery *query = self.baseQuery.copy;
+
+	NSArray <NSDictionary *> *pulledRelations = [properties select:^BOOL(id object) {
+		return [object isKindOfClass:[NSDictionary class]];
+	}];
+	properties = [properties relativeComplement:pulledRelations];
+
+	query.select(properties).where(^(GDGCondition *builder) {
+		builder.prop(@"id").inList(ids);
+	});
+
+	for (NSDictionary *relation in pulledRelations)
+		query.pull(relation);
 
 	if (self.condition)
 		query.where(^(GDGCondition *builder) {
 			builder.and.cat(self.condition);
 		});
 
+	NSMutableArray *unfilledEntities = [entities mutableCopy];
+
 	for (GDGEntity *relatedEntity in query.array)
 	{
-		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[@([relatedEntity id])];
+		NSMutableArray<GDGEntity *> *mutableEntities = relationEntitiesDictionary[@(relatedEntity.id)];
 		for (GDGEntity *entity in mutableEntities)
+		{
 			[entity setValue:relatedEntity forKey:self.name];
+			[unfilledEntities removeObject:entity];
+		}
 	}
+
+	for (GDGEntity *unfilledEntity in unfilledEntities)
+		[unfilledEntity setValue:nil forKey:self.name];
 }
 
-- (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource
+- (void)set:(GDGEntity *)value onEntity:(GDGEntity *)entity
 {
-	NSMutableString *condition = [[NSMutableString alloc] initWithString:joinedSource.identifier];
-
-	[condition appendFormat:@".%@ = %@.id", [self.manager columnNameForProperty:self.foreignProperty], source.identifier];
-
-	return [NSString stringWithString:condition];
+	[entity setValue:@(value.id) forKey:self.foreignProperty];
 }
 
 @end

--- a/Pod/Classes/GDGCondition.h
+++ b/Pod/Classes/GDGCondition.h
@@ -22,8 +22,7 @@
 @property (copy, readonly, nonatomic) GDGCondition *(^lt)(id);
 @property (copy, readonly, nonatomic) GDGCondition *(^lte)(id);
 @property (copy, readonly, nonatomic) GDGCondition *(^notEquals)(id);
-@property (copy, readonly, nonatomic) GDGCondition *(^isNull)();
-@property (copy, readonly, nonatomic) GDGCondition *(^isNotNull)();
+@property (copy, readonly, nonatomic) GDGCondition *(^in)(id);
 @property (copy, readonly, nonatomic) GDGCondition *(^inText)(NSString *);
 @property (copy, readonly, nonatomic) GDGCondition *(^inList)(NSArray<NSNumber *> *);
 @property (copy, readonly, nonatomic) GDGCondition *(^inQuery)(GDGQuery *);
@@ -37,9 +36,9 @@
 
 - (GDGCondition *)or;
 
-- (GDGCondition *)openParentheses;
+- (GDGCondition *)null;
 
-- (GDGCondition *)closeParentheses;
+- (GDGCondition *)notNull;
 
 - (NSString *)visit;
 

--- a/Pod/Classes/GDGCondition.m
+++ b/Pod/Classes/GDGCondition.m
@@ -22,7 +22,8 @@
 
 @end
 
-@implementation GDGCondition
+@implementation
+GDGCondition
 
 + (instancetype)builder
 {
@@ -89,12 +90,9 @@
 			return [weakSelf build:builderHandler];
 		};
 
-		_isNull = ^GDGCondition * {
-			return [weakSelf appendText:@"IS NULL"];
-		};
-
-		_isNotNull = ^GDGCondition * {
-			return [weakSelf appendText:@"IS NOT NULL"];
+		_in = ^GDGCondition *(id arg) {
+			return [arg isKindOfClass:[GDGQuery class]] ? _inQuery(arg) :
+					[arg isKindOfClass:[NSArray class]] ? _inList(arg) : _inText(arg);
 		};
 
 		_inText = ^GDGCondition *(NSString *text) {
@@ -166,14 +164,14 @@
 	return [self appendText:@"OR"];
 }
 
-- (GDGCondition *)openParentheses
+- (GDGCondition *)null
 {
-	return [self appendText:@"("];
+	return [self appendText:@"IS NULL"];
 }
 
-- (GDGCondition *)closeParentheses
+- (GDGCondition *)notNull
 {
-	return [self appendText:@")"];
+	return [self appendText:@"IS NOT NULL"];
 }
 
 - (GDGCondition *)appendValue:(id)value forOperator:(NSString *)operator

--- a/Pod/Classes/GDGEntity.h
+++ b/Pod/Classes/GDGEntity.h
@@ -21,7 +21,7 @@
 
 @interface GDGEntity : NSObject
 
-@property (assign, nonatomic) NSUInteger id;
+@property (assign, nonatomic) NSInteger id;
 @property (readonly, nonatomic) GDGEntityManager <GDGEntityFillDelegate> *db;
 
 + (instancetype)entity;

--- a/Pod/Classes/GDGEntityQuery.h
+++ b/Pod/Classes/GDGEntityQuery.h
@@ -20,10 +20,26 @@
 
 @interface GDGEntityQuery : GDGQuery
 
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^select)(NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^from)(GDGSource *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^fromTable)(NSString *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^join)(__kindof GDGSource *, NSString *, NSString *, NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^joinTable)(NSString *, NSString *, NSString *, NSArray<NSString *> *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^where)(void (^)(GDGCondition *));
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^asc)(NSString *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^desc)(NSString *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^limit)(int);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^filter)(NSArray<id <GDGFilter>> *);
+
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^pull)(NSDictionary <NSString *, NSArray *> *);
+@property (copy, readonly, nonatomic) GDGEntityQuery *(^id)(NSInteger);
 @property (copy, readonly, nonatomic) GDGEntityQuery *(^joinRelation)(NSString *, NSArray<NSString *> *);
 
+@property (readonly, nonatomic) NSDictionary <NSString *, NSArray *> *pulledRelations;
 @property (readonly, nonatomic) GDGEntityManager *manager;
 
 - (instancetype)initWithManager:(GDGEntityManager *)manager;
+
+- (instancetype)copy;
 
 @end

--- a/Pod/Classes/GDGHasOneRelation.m
+++ b/Pod/Classes/GDGHasOneRelation.m
@@ -15,30 +15,53 @@
 
 - (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
 {
-	NSArray<NSNumber *> *ids = [entities map:^id(id object) {
-		return @([object id]);
+	NSArray<NSNumber *> *ids = [entities map:^id(GDGEntity *object) {
+		return @(object.id);
 	}];
 
 	NSDictionary<NSNumber *, GDGEntity *> *idEntitiesDictionary = [NSDictionary dictionaryWithObjects:entities forKeys:ids];
 
-	NSMutableArray *mutableProperties = [NSMutableArray arrayWithArray:properties];
-	[mutableProperties addObject:self.foreignProperty];
+	NSArray <NSDictionary *> *pulledRelations = [properties select:^BOOL(id object) {
+		return [object isKindOfClass:[NSDictionary class]];
+	}];
+	properties = [[properties relativeComplement:pulledRelations] arrayByAddingObject:self.foreignProperty];
 
-	GDGEntityQuery *query = self.relatedManager.query.select([NSArray arrayWithArray:mutableProperties])
-			.where(^(GDGCondition *builder) {
-				builder.prop(self.foreignProperty).inList(ids);
-			});
+	GDGEntityQuery *query = self.relatedManager.query.copy;
+	query.select(properties).where(^(GDGCondition *builder) {
+		builder.prop(self.foreignProperty).inList(ids);
+	});
+
+	for (NSDictionary *relation in pulledRelations)
+		query.pull(relation);
 
 	if (self.condition)
 		query.where(^(GDGCondition *builder) {
 			builder.and.cat(self.condition);
 		});
 
+	NSMutableArray *unfilledEntities = [entities mutableCopy];
+
 	for (GDGEntity *relatedEntity in query.array)
 	{
 		GDGEntity *entity = idEntitiesDictionary[[relatedEntity valueForKey:self.foreignProperty]];
 		[entity setValue:relatedEntity forKey:self.name];
+
+		[unfilledEntities removeObject:entity];
 	}
+
+	for (GDGEntity *unfilledEntity in unfilledEntities)
+		[unfilledEntity setValue:nil forKey:self.name];
+}
+
+- (void)set:(GDGEntity *)value onEntity:(GDGEntity *)entity
+{
+	[value setValue:@(entity.id) forKey:self.foreignProperty];
+}
+
+- (void)save:(GDGEntity *)entity
+{
+	GDGEntity *owned = [entity valueForKey:self.foreignProperty];
+	[owned.db save];
 }
 
 @end

--- a/Pod/Classes/GDGRelation.h
+++ b/Pod/Classes/GDGRelation.h
@@ -19,13 +19,18 @@
 @property (strong, nonatomic) GDGEntityManager *relatedManager;
 @property (strong, nonatomic) NSString *foreignProperty;
 @property (strong, nonatomic) GDGCondition *condition;
+@property (strong, nonatomic) GDGEntityQuery *baseQuery;
 
 - (instancetype)initWithName:(NSString *)name manager:(GDGEntityManager *)manager;
-
-- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties;
 
 - (NSString *)joinCondition;
 
 - (NSString *)joinConditionFromSource:(GDGSource *)source toSource:(GDGSource *)joinedSource;
+
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray *)properties;
+
+- (void)set:(__kindof NSObject *)value onEntity:(GDGEntity *)entity;
+
+- (void)save:(GDGEntity *)entity;
 
 @end

--- a/Pod/Classes/GDGRelation.m
+++ b/Pod/Classes/GDGRelation.m
@@ -9,7 +9,7 @@
 
 #import "GDGEntitySettings.h"
 #import "GDGTableSource.h"
-#import "GDGSource.h"
+#import "GDGEntityQuery.h"
 
 @implementation GDGRelation
 
@@ -33,6 +33,11 @@
 	_foreignProperty = [[className stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:[[className substringToIndex:1] lowercaseString]] stringByAppendingString:@"Id"];
 }
 
+- (GDGEntityQuery *)baseQuery
+{
+	return _relatedManager.query.copy;
+}
+
 - (NSString *)joinCondition
 {
 	return [self joinConditionFromSource:_manager.settings.tableSource toSource:_relatedManager.settings.tableSource];
@@ -47,9 +52,25 @@
 	return [NSString stringWithString:condition];
 }
 
-- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray<NSString *> *)properties
+- (void)save:(GDGEntity *)entity
 {
-	@throw [[NSException alloc] initWithName:@"Not Implemented" reason:@"TODO" userInfo:nil];
+	// Default implementation does nothing
+}
+
+#pragma mark - Abstract
+
+- (void)fill:(NSArray<GDGEntity *> *)entities withProperties:(NSArray *)properties
+{
+	@throw [NSException exceptionWithName:@"Abstract Implementation Exception"
+	                               reason:@"[GDGRelation -fill:withProperties:] throws that child classes must override this method"
+	                             userInfo:nil];
+}
+
+- (void)set:(__kindof NSObject *)value onEntity:(GDGEntity *)entity
+{
+	@throw [NSException exceptionWithName:@"Abstract Implementation Exception"
+	                               reason:@"[GDGRelation -set:onEntity:] throws that child classes must override this method"
+	                             userInfo:nil];
 }
 
 @end


### PR DESCRIPTION
Well, being direct, this PR is about 3 things:

The **first** one, and more complex of then, is the loading, saving and _pulling_ of relations. It changes some strategies that we have been adopting in its core, and may not be ready to be shipped yet (keep that in mind when you are going through the code).
- First and foremost, the `-overrideSetter:forClass` had to be updated in order to make possible setting relations foreign properties when that is pertinent;
- Methods of the `fill` kind were update so entities being filled would have their relations filled if necessary
- At `GDGEntityQuery` was add the `^pull(dict<str, array>)` block so you can build _entity queries_ pulling it's relations

**Secondly**, ids were conventioned to be positive integers (or naturals if you prefer). Due to a couple common strategies of identifier categorization, the timestamp and "under zero, over zero", I've decided then to support full integer ids (why not?).

And last but not the least, in **third** place there are some other additions, like: 
- `^id(int)` block at `GDGEntityQuery` which adds a `WHERE id = ?` to query's condition
- `^in(id)` block to `GDGCondition` as a sintax sugar over the other in* blocks.
