### PR TITLE
Add -save: to relations and some fixes

### DIFF
--- a/Pod/Core/GDGRelation.h
+++ b/Pod/Core/GDGRelation.h
@@ -32,6 +32,8 @@
 
 - (void)hasBeenSetOnEntity:(GDGEntity *)entity;
 
+- (void)save:(GDGEntity *)entity;
+
 - (GDGCondition *)joinCondition;
 
 - (GDGCondition *)joinConditionFromSource:(id <GDGSource>)source toSource:(id <GDGSource>)joinedSource;

--- a/Pod/Core/GDGRelation.h
+++ b/Pod/Core/GDGRelation.h
@@ -32,7 +32,7 @@
 
 - (void)hasBeenSetOnEntity:(GDGEntity *)entity;
 
-- (void)save:(GDGEntity *)entity;
+- (BOOL)save:(GDGEntity *)entity error:(NSError **)error;
 
 - (GDGCondition *)joinCondition;
 

--- a/Pod/Core/GDGRelation.m
+++ b/Pod/Core/GDGRelation.m
@@ -9,6 +9,7 @@
 
 #import "GDGEntityMap.h"
 #import "GDGQuery.h"
+#import "GDGEntity+SQL.h"
 
 @implementation GDGRelationField
 
@@ -56,7 +57,19 @@
 	// Default implementation does nothing
 }
 
+- (void)save:(GDGEntity *)entity
+{
+	// Default implementation does nothing
+}
+
 #pragma mark - Abstract
+
+- (void)fill:(NSArray <GDGEntity *> *)entities selecting:(NSArray *)properties
+{
+	@throw [NSException exceptionWithName:@"Abstract Implementation Exception"
+	                               reason:@"[GDGRelation -fill:selecting:] throws that child classes must override this method"
+	                             userInfo:nil];
+}
 
 - (void)fill:(NSArray<GDGEntity *> *)entities fromQuery:(__kindof GDGQuery *)query
 {

--- a/Pod/Core/GDGRelation.m
+++ b/Pod/Core/GDGRelation.m
@@ -57,9 +57,10 @@
 	// Default implementation does nothing
 }
 
-- (void)save:(GDGEntity *)entity
+- (BOOL)save:(GDGEntity *)entity error:(NSError **)error
 {
 	// Default implementation does nothing
+	return YES;
 }
 
 #pragma mark - Abstract

--- a/Pod/SQL/GDGBelongsToRelation.m
+++ b/Pod/SQL/GDGBelongsToRelation.m
@@ -17,8 +17,8 @@
 - (GDGCondition *)joinConditionFromSource:(id <GDGSource>)source toSource:(id <GDGSource>)joinedSource
 {
 	return [GDGCondition builder]
-			.field([GDGRelationField relationFieldWithName:((GDGColumn *) self.map[self.foreignProperty]).name source:joinedSource])
-			.equals([GDGRelationField relationFieldWithName:@"id" source:source]);
+			.field([GDGRelationField relationFieldWithName:((GDGColumn *) self.map[self.foreignProperty]).name source:source])
+			.equals([GDGRelationField relationFieldWithName:@"id" source:joinedSource]);
 }
 
 - (void)fill:(NSArray <GDGEntity *> *)entities selecting:(NSArray *)properties

--- a/Pod/SQL/GDGEntity+SQL.m
+++ b/Pod/SQL/GDGEntity+SQL.m
@@ -98,7 +98,11 @@
 		NSArray <NSDictionary *> *entries = [self.db.table eval:query];
 
 		if (entries.count == 0)
-			NSLog(@"Errou!!");
+			@throw [NSException exceptionWithName:@"Query Evaluation Inconsistency"
+			                               reason:@"[GDGEntity+SQL -fill:withProperties:] throws that properties query "
+					                               @"evaluation should never get nil evalutation. You may have mapped "
+					                               @"something that is not a property or something that is not a column."
+			                             userInfo:nil];
 
 		for (unsigned int i = 0; i < ids.count; ++i)
 		{
@@ -235,7 +239,7 @@
 		self.id = [db.table lastInsertedId];
 
 	for (GDGRelation *relation in relations)
-		[relation save:self];
+		[relation save:self error:NULL];
 
 	if (saved)
 		[self.changedProperties removeAllObjects];

--- a/Pod/SQL/GDGHasManyRelation.m
+++ b/Pod/SQL/GDGHasManyRelation.m
@@ -112,14 +112,16 @@
 			[owned setValue:entity.id forKey:self.foreignProperty];
 }
 
-- (void)save:(GDGEntity *)entity
+- (BOOL)save:(GDGEntity *)entity error:(NSError **)error
 {
 	for (GDGEntity *related in [entity valueForKey:self.name])
 	{
 		[related setValue:entity.id forKey:self.foreignProperty];
-		if (![related save:nil])
-			NSLog(((SQLEntityMap *)self.relatedMap).table.databaseProvider.database.lastErrorMessage, nil);
+		if (![related save:error])
+			return NO;
 	}
+
+	return YES;
 }
 
 @end

--- a/Pod/SQL/GDGHasManyRelation.m
+++ b/Pod/SQL/GDGHasManyRelation.m
@@ -12,6 +12,10 @@
 #import "SQLEntityQuery.h"
 #import "GDGEntity.h"
 #import "GDGColumn.h"
+#import "GDGEntity+SQL.h"
+#import "SQLTableSource.h"
+#import "GDGDatabaseProvider.h"
+#import <SQLAid/CIRDatabase.h>
 
 @implementation GDGHasManyRelation
 
@@ -103,8 +107,19 @@
 
 - (void)hasBeenSetOnEntity:(GDGEntity *)entity
 {
-	for (GDGEntity *owned in [entity valueForKey:self.name])
-		[owned setValue:entity.id forKey:self.foreignProperty];
+	if (entity.id != nil)
+		for (GDGEntity *owned in [entity valueForKey:self.name])
+			[owned setValue:entity.id forKey:self.foreignProperty];
+}
+
+- (void)save:(GDGEntity *)entity
+{
+	for (GDGEntity *related in [entity valueForKey:self.name])
+	{
+		[related setValue:entity.id forKey:self.foreignProperty];
+		if (![related save:nil])
+			NSLog(((SQLEntityMap *)self.relatedMap).table.databaseProvider.database.lastErrorMessage, nil);
+	}
 }
 
 @end

--- a/Pod/SQL/GDGHasManyThroughRelation.h
+++ b/Pod/SQL/GDGHasManyThroughRelation.h
@@ -16,9 +16,7 @@
 @property (strong, nonatomic) NSString *localRelationColumn;
 @property (strong, nonatomic) NSString *foreignRelationColumn;
 
-- (void)save:(GDGEntity *)entity;
-
-- (void)insertOrReplaceOwner:(NSNumber *)ownerId forRelated:(NSArray <NSNumber *> *)related;
+- (BOOL)insertOrReplaceOwner:(NSNumber *)ownerId forRelated:(NSArray <NSNumber *> *)related error:(NSError **)error;
 
 - (CIRStatement *)insertStatement;
 

--- a/Pod/SQL/GDGHasOneRelation.m
+++ b/Pod/SQL/GDGHasOneRelation.m
@@ -74,12 +74,13 @@
 		[unfilledEntity setValue:nil forKey:self.name];
 }
 
-- (void)save:(GDGEntity *)entity
+- (BOOL)save:(GDGEntity *)entity error:(NSError **)error
 {
 	GDGEntity *related = [entity valueForKey:self.name];
 
 	[related setValue:entity.id forKey:self.foreignProperty];
-	[related save:nil];
+
+	return [related save:error];
 }
 
 @end

--- a/Pod/SQL/GDGHasOneRelation.m
+++ b/Pod/SQL/GDGHasOneRelation.m
@@ -13,6 +13,7 @@
 #import "GDGCondition+Entity.h"
 #import "GDGEntity.h"
 #import "GDGColumn.h"
+#import "GDGEntity+SQL.h"
 
 @implementation GDGHasOneRelation
 
@@ -71,6 +72,14 @@
 
 	for (GDGEntity *unfilledEntity in unfilledEntities)
 		[unfilledEntity setValue:nil forKey:self.name];
+}
+
+- (void)save:(GDGEntity *)entity
+{
+	GDGEntity *related = [entity valueForKey:self.name];
+
+	[related setValue:entity.id forKey:self.foreignProperty];
+	[related save:nil];
 }
 
 @end

--- a/Pod/SQL/SQLQuery.m
+++ b/Pod/SQL/SQLQuery.m
@@ -223,15 +223,33 @@
 
 	NSArray *operatorTokens = @[@"=", @">", @">=", @"<", @"<=", @"<>"];
 	NSString *token = nil;
-	NSArray *tokens = condition.tokens;
 	NSDictionary *fields = condition.fields;
-	NSDictionary *conditionArgs = condition.args;
+	NSMutableArray *tokens = condition.tokens.mutableCopy;
+	NSMutableDictionary *conditionArgs = condition.args.mutableCopy;
+
+	for (NSString *key in condition.args.keyEnumerator)
+	{
+		NSString *newKey = key;
+
+		if ([_mutableArgs hasKey:key])
+		{
+			unsigned int random = arc4random() % 10000;
+
+			newKey = NSStringWithFormat(@"%@_%u", key, random);
+
+			conditionArgs[newKey] = conditionArgs[key];
+
+			tokens[[tokens indexOfObject:key]] = newKey;
+
+			[conditionArgs removeObjectForKey:key];
+		}
+
+		_mutableArgs[newKey] = conditionArgs[newKey];
+	}
 
 	for (NSUInteger i = 0; i < tokens.count; i++)
 	{
 		token = tokens[i];
-
-		[_mutableArgs addEntriesFromDictionary:condition.args];
 
 		if ([token isEqualToString:@"("])
 			[mutableCondition appendString:@"("];


### PR DESCRIPTION
The purpose of this pull-request is to make it possible to automatically save _changed_ relations from the method:

``` objective-c
- (BOOL)save:(NSError **)error
```

which is defined in `GDGRelation+SQL` category.

Besides, this pull-request fixes `-joinCondition` in `GDGBelongsToRelation` that was calling the `-joinConditionFromSource:toSource:` passing the parameters in the wrong order.
