### PR TITLE
Saving "belongs to" relations

### DIFF
--- a/Pod/SQL/GDGBelongsToRelation.m
+++ b/Pod/SQL/GDGBelongsToRelation.m
@@ -8,7 +8,7 @@
 #import <ObjectiveSugar/ObjectiveSugar.h>
 #import "GDGBelongsToRelation.h"
 #import "GDGCondition+Entity.h"
-#import "GDGEntity.h"
+#import "GDGEntity+SQL.h"
 #import "GDGColumn.h"
 #import "SQLEntityQuery.h"
 
@@ -102,6 +102,19 @@
 
 	for (GDGEntity *unfilledEntity in unfilledEntities)
 		[unfilledEntity setValue:nil forKey:self.name];
+}
+
+- (BOOL)save:(GDGEntity *)entity error:(NSError **)error
+{
+	GDGEntity *related = [entity valueForKey:self.name];
+
+	if ([related save:error])
+	{
+		[entity setValue:related.id forKey:self.foreignProperty];
+		return YES;
+	}
+
+	return NO;
 }
 
 - (void)hasBeenSetOnEntity:(GDGEntity *)entity

--- a/Pod/SQL/GDGEntity+SQL.m
+++ b/Pod/SQL/GDGEntity+SQL.m
@@ -289,8 +289,10 @@
 	if (exists)
 	{
 		for (NSString *key in primaryKeys)
+		{
+			[columns addObject:[db columnNameForProperty:key]];
 			[values addObject:[self valueForKey:key]];
-			
+		}
 		saved = [db.table update:columns params:values error:error];
 	}
 	else


### PR DESCRIPTION
This _pull-request_ simply implements the inherited method `-save:error:` of a `GDGRelation` in the `GDGBelongsToRelation`.

Besides, it fixes a minor error in the `-save:` method of `GDGEntity`'s SQL extension.