### PR TITLE
Impede unnecessary query executions

### DIFF
--- a/Pod/SQL/GDGBelongsToRelation.m
+++ b/Pod/SQL/GDGBelongsToRelation.m
@@ -76,6 +76,8 @@
 		return object != [NSNull null];
 	}];
 
+	if (ids.count == 0) return;
+
 	query.where(^(GDGCondition *builder) {
 		builder.prop(@"id").in(ids);
 	});


### PR DESCRIPTION
If all ids are null, impede execution of queries at belongs to relation `-fill:fromQuery:` method.