### PR TITLE
set reference to table source weak

### DIFF
--- a/Pod/SQL/GDGColumn.h
+++ b/Pod/SQL/GDGColumn.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, GDGColumnType)
 @interface GDGColumn : NSObject <NSCopying, GDGConditionField>
 
 @property (strong, nonatomic) NSString *name;
-@property (strong, nonatomic) SQLTableSource *table;
+@property (weak, nonatomic) SQLTableSource *table;
 @property (assign, nonatomic) GDGColumnType type;
 @property (assign, nonatomic) int primaryKey;
 @property (assign, nonatomic, getter=isNotNull) BOOL notNull;


### PR DESCRIPTION
This PR fix a memory leak in GDGCollumn setting reference to table source weak.
<img width="818" alt="screen shot 2018-06-18 at 4 02 28 pm" src="https://user-images.githubusercontent.com/3781302/41784165-41142ec0-7615-11e8-81a1-3af2ae34b110.png">
