### PR TITLE
Fix cat condition

### DIFF
--- a/Pod/Core/GDGCondition.m
+++ b/Pod/Core/GDGCondition.m
@@ -76,8 +76,10 @@
 		};
 
 		_cat = ^GDGCondition *(GDGCondition *builder) {
-			[weakSelf.mutableArgs addEntriesFromDictionary:builder.mutableArgs];
+			[weakSelf.mutableFields addEntriesFromDictionary:builder->_mutableFields];
+			[weakSelf.mutableArgs addEntriesFromDictionary:builder->_mutableArgs];
 			[weakSelf.mutableTokens addObjectsFromArray:builder->_mutableTokens];
+			
 			return weakSelf;
 		};
 	}

--- a/Pod/SQL/SQLQuery.m
+++ b/Pod/SQL/SQLQuery.m
@@ -286,9 +286,9 @@
 		}
 		else if ([token hasPrefix:@"ARG_"])
 			[mutableCondition appendString:[@":" stringByAppendingString:token]];
-		else if ([token isEqualToString:@"AND"])
+		else if ([token isEqualToString:@"AND"] && [mutableCondition length] > 0)
 			[mutableCondition appendString:@"AND"];
-		else if ([token isEqualToString:@"OR"])
+		else if ([token isEqualToString:@"OR"] && [mutableCondition length] > 0)
 			[mutableCondition appendString:@"OR"];
 		else if ([token isEqualToString:@"NULL"])
 			[mutableCondition appendString:@"IS NULL"];


### PR DESCRIPTION
# Problem
The `cat` condition wasn't adding fields, just the `args` and `tokens`.

# Solution
Add **fields** to the `cat` mutable condition and validate `AND`, `OR` condition for don't create inconsistent query.

## Attention
* This pull request must be approved in September, when we'll release the version for customers.