### PR TITLE
fix string replacement

### DIFF
--- a/Pod/SQL/SQLQuery.m
+++ b/Pod/SQL/SQLQuery.m
@@ -298,9 +298,7 @@
 		[mutableCondition appendString:@" "];
 	}
 
-	[mutableCondition replaceCharactersInRange:NSMakeRange(mutableCondition.length - 1, 1) withString:@""];
-
-	return [NSString stringWithString:mutableCondition];
+    return [NSString stringWithString:mutableCondition];
 }
 
 - (NSString *)visitJoin:(SQLJoin *)join disambiguate:(NSString *(^)(SQLQuery *))disambiguationHandler


### PR DESCRIPTION
Removendo replace que está causando crash em alguns casos por motivos de index out of bound.

Esse replace não faz muito sentido pois ele está só removendo o espaço final adicionado à query, porém esse espaço não é levado em consideração numa query, tornando desnecessário.